### PR TITLE
Edit api fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "helius-sdk",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "helius-sdk",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.2.3"

--- a/src/Helius.ts
+++ b/src/Helius.ts
@@ -6,9 +6,6 @@ import {
     MintlistRequest,
     MintlistResponse,
     MintlistItem,
-    Address,
-    TransactionType,
-    WebhookType,
 } from "./types";
 
 import axios, { type AxiosError } from "axios";

--- a/src/Helius.ts
+++ b/src/Helius.ts
@@ -1,11 +1,14 @@
-import type {
+import {
     Webhook,
     CreateWebhookRequest,
     EditWebhookRequest,
     CreateCollectionWebhookRequest,
     MintlistRequest,
     MintlistResponse,
-    MintlistItem
+    MintlistItem,
+    Address,
+    TransactionType,
+    WebhookType,
 } from "./types";
 
 import axios, { type AxiosError } from "axios";
@@ -14,12 +17,11 @@ import { PublicKey } from "@solana/web3.js";
 const API_URL_V0: string = "https://api.helius.xyz/v0";
 const API_URL_V1: string = "https://api.helius.xyz/v1";
 
-/** 
+/**
  * This is the base level class for interfacing with all Helius API methods.
  * @class
  */
 export class Helius {
-
     /**
      * API key generated at dev.helius.xyz
      * @private
@@ -27,7 +29,7 @@ export class Helius {
     private apiKey: string;
 
     /**
-     * Initializes Helius API client with an API key 
+     * Initializes Helius API client with an API key
      * @constructor
      * @param apiKey - API key generated at dev.helius.xyz
      */
@@ -36,10 +38,10 @@ export class Helius {
     }
 
     /**
-    * Retrieves a list of all webhooks associated with the current API key
-    * @returns {Promise<Webhook[]>} a promise that resolves to an array of webhook objects
-    * @throws {Error} if there is an error calling the webhooks endpoint or if the response contains an error
-    */
+     * Retrieves a list of all webhooks associated with the current API key
+     * @returns {Promise<Webhook[]>} a promise that resolves to an array of webhook objects
+     * @throws {Error} if there is an error calling the webhooks endpoint or if the response contains an error
+     */
     async getAllWebhooks(): Promise<Webhook[]> {
         try {
             const { data } = await axios.get(
@@ -48,202 +50,310 @@ export class Helius {
             return data;
         } catch (err: any | AxiosError) {
             if (axios.isAxiosError(err)) {
-                throw new Error(`error calling getWebhooks: ${err.response?.data.error || err}`)
+                throw new Error(
+                    `error calling getWebhooks: ${
+                        err.response?.data.error || err
+                    }`
+                );
             } else {
-                throw new Error(`error calling getWebhooks: ${err}`)
+                throw new Error(`error calling getWebhooks: ${err}`);
             }
         }
     }
 
     /**
-    * Retrieves a single webhook by its ID, associated with the current API key
-    * @param {string} webhookID - the ID of the webhook to retrieve
-    * @returns {Promise<Webhook>} a promise that resolves to a webhook object
-    * @throws {Error} if there is an error calling the webhooks endpoint or if the response contains an error
-    */
+     * Retrieves a single webhook by its ID, associated with the current API key
+     * @param {string} webhookID - the ID of the webhook to retrieve
+     * @returns {Promise<Webhook>} a promise that resolves to a webhook object
+     * @throws {Error} if there is an error calling the webhooks endpoint or if the response contains an error
+     */
     async getWebhookByID(webhookID: string): Promise<Webhook> {
         try {
-            const { data } = await axios.get(`${API_URL_V0}/webhooks/${webhookID}?api-key=${this.apiKey}`)
-            return data
-        } catch (err: any | AxiosError) {
-            if (axios.isAxiosError(err)) {
-                throw new Error(`error during getWebhookByID: ${err.response?.data.error || err}`)
-            } else {
-                throw new Error(`error during getWebhookByID: ${err}`)
-            }
-        }
-    }
-
-    /**
-    * Creates a new webhook with the provided request
-    * @param {CreateWebhookRequest} createWebhookRequest - the request object containing the webhook information
-    * @returns {Promise<Webhook>} a promise that resolves to the created webhook object
-    * @throws {Error} if there is an error calling the webhooks endpoint or if the response contains an error
-    */
-    async createWebhook(createWebhookRequest: CreateWebhookRequest): Promise<Webhook> {
-        const addressesOffCurve = createWebhookRequest.accountAddresses.filter((address) => !PublicKey.isOnCurve(address))
-        if (addressesOffCurve.length > 0) {
-            throw new Error(`bad 'accountAddresses' parameter, addresses [${addressesOffCurve.toString()}] are invalid`)
-        }
-
-        try {
-            const { data } = await axios.post(`${API_URL_V0}/webhooks?api-key=${this.apiKey}`, { ...createWebhookRequest })
+            const { data } = await axios.get(
+                `${API_URL_V0}/webhooks/${webhookID}?api-key=${this.apiKey}`
+            );
             return data;
         } catch (err: any | AxiosError) {
             if (axios.isAxiosError(err)) {
-                throw new Error(`error during createWebhook: ${err.response?.data.error || err}`)
+                throw new Error(
+                    `error during getWebhookByID: ${
+                        err.response?.data.error || err
+                    }`
+                );
             } else {
-                throw new Error(`error during createWebhook: ${err}`)
+                throw new Error(`error during getWebhookByID: ${err}`);
             }
         }
     }
 
     /**
-    * Deletes a webhook by its ID
-    * @param {string} webhookID - the ID of the webhook to delete
-    * @returns {Promise<boolean>} a promise that resolves to true if the webhook was successfully deleted, or false otherwise
-    * @throws {Error} if there is an error calling the webhooks endpoint or if the response contains an error
-    */
+     * Creates a new webhook with the provided request
+     * @param {CreateWebhookRequest} createWebhookRequest - the request object containing the webhook information
+     * @returns {Promise<Webhook>} a promise that resolves to the created webhook object
+     * @throws {Error} if there is an error calling the webhooks endpoint or if the response contains an error
+     */
+    async createWebhook(
+        createWebhookRequest: CreateWebhookRequest
+    ): Promise<Webhook> {
+        const addressesOffCurve = createWebhookRequest.accountAddresses.filter(
+            (address) => !PublicKey.isOnCurve(address)
+        );
+        if (addressesOffCurve.length > 0) {
+            throw new Error(
+                `bad 'accountAddresses' parameter, addresses [${addressesOffCurve.toString()}] are invalid`
+            );
+        }
+
+        try {
+            const { data } = await axios.post(
+                `${API_URL_V0}/webhooks?api-key=${this.apiKey}`,
+                { ...createWebhookRequest }
+            );
+            return data;
+        } catch (err: any | AxiosError) {
+            if (axios.isAxiosError(err)) {
+                throw new Error(
+                    `error during createWebhook: ${
+                        err.response?.data.error || err
+                    }`
+                );
+            } else {
+                throw new Error(`error during createWebhook: ${err}`);
+            }
+        }
+    }
+
+    /**
+     * Deletes a webhook by its ID
+     * @param {string} webhookID - the ID of the webhook to delete
+     * @returns {Promise<boolean>} a promise that resolves to true if the webhook was successfully deleted, or false otherwise
+     * @throws {Error} if there is an error calling the webhooks endpoint or if the response contains an error
+     */
     async deleteWebhook(webhookID: string): Promise<boolean> {
         try {
-            await axios.delete(`${API_URL_V0}/webhooks/${webhookID}?api-key=${this.apiKey}`)
-            return true
+            await axios.delete(
+                `${API_URL_V0}/webhooks/${webhookID}?api-key=${this.apiKey}`
+            );
+            return true;
         } catch (err: any | AxiosError) {
             if (axios.isAxiosError(err)) {
-                throw new Error(`error during deleteWebhook: ${err.response?.data.error || err}`)
+                throw new Error(
+                    `error during deleteWebhook: ${
+                        err.response?.data.error || err
+                    }`
+                );
             } else {
-                throw new Error(`error during deleteWebhook: ${err}`)
+                throw new Error(`error during deleteWebhook: ${err}`);
             }
         }
     }
 
     /**
-    * Edits an existing webhook by its ID with the provided request
-    * @param {string} webhookID - the ID of the webhook to edit
-    * @param {EditWebhookRequest} editWebhookRequest - the request object containing the webhook information
-    * @returns {Promise<Webhook>} a promise that resolves to the edited webhook object
-    * @throws {Error} if there is an error calling the webhooks endpoint or if the response contains an error
-    */
-    async editWebhook(webhookID: string, editWebhookRequest: EditWebhookRequest): Promise<Webhook> {
-        const addressesOffCurve = editWebhookRequest.accountAddresses.filter((address) => !PublicKey.isOnCurve(address))
-        if (addressesOffCurve.length > 0) {
-            throw new Error(`bad 'accountAddresses' parameter, addresses [${addressesOffCurve.toString()}] are invalid`)
+     * Edits an existing webhook by its ID with the provided request
+     * @param {string} webhookID - the ID of the webhook to edit
+     * @param {EditWebhookRequest} editWebhookRequest - the request object containing the webhook information
+     * @returns {Promise<Webhook>} a promise that resolves to the edited webhook object
+     * @throws {Error} if there is an error calling the webhooks endpoint or if the response contains an error
+     */
+    async editWebhook(
+        webhookID: string,
+        editWebhookRequest: EditWebhookRequest
+    ): Promise<Webhook> {
+        if (editWebhookRequest.accountAddresses) {
+            const addressesOffCurve =
+                editWebhookRequest.accountAddresses.filter(
+                    (address) => !PublicKey.isOnCurve(address)
+                );
+            if (addressesOffCurve.length > 0) {
+                throw new Error(
+                    `bad 'accountAddresses' parameter, addresses [${addressesOffCurve.toString()}] are invalid`
+                );
+            }
         }
 
         try {
             const webhook = await this.getWebhookByID(webhookID);
-            const { data } = await axios.put(`${API_URL_V0}/webhooks/${webhookID}?api-key=${this.apiKey}`, { ...webhook, ...editWebhookRequest })
+            const editRequest: Partial<Webhook> = {
+                ...webhook,
+                ...editWebhookRequest,
+            };
+            delete editRequest["webhookID"];
+            delete editRequest["wallet"];
+
+            const { data } = await axios.put(
+                `${API_URL_V0}/webhooks/${webhookID}?api-key=${this.apiKey}`,
+                editRequest
+            );
             return data;
         } catch (err: any | AxiosError) {
             if (axios.isAxiosError(err)) {
-                throw new Error(`error during editWebhook: ${err.response?.data.error || err}`)
+                throw new Error(
+                    `error during editWebhook: ${
+                        err.response?.data.error || err
+                    }`
+                );
             } else {
-                throw new Error(`error during editWebhook: ${err}`)
+                throw new Error(`error during editWebhook: ${err}`);
             }
         }
     }
 
     /**
-    * Appends an array of addresses to an existing webhook by its ID
-    * @param {string} webhookID - the ID of the webhook to edit
-    * @param {string[]} newAccountAddresses - the array of addresses to be added to the webhook
-    * @returns {Promise<Webhook>} a promise that resolves to the edited webhook object
-    * @throws {Error} if there is an error calling the webhooks endpoint, if the response contains an error, or if the number of addresses exceeds 10,000
-    */
-    async appendAddressesToWebhook(webhookID: string, newAccountAddresses: string[]): Promise<Webhook> {
+     * Appends an array of addresses to an existing webhook by its ID
+     * @param {string} webhookID - the ID of the webhook to edit
+     * @param {string[]} newAccountAddresses - the array of addresses to be added to the webhook
+     * @returns {Promise<Webhook>} a promise that resolves to the edited webhook object
+     * @throws {Error} if there is an error calling the webhooks endpoint, if the response contains an error, or if the number of addresses exceeds 10,000
+     */
+    async appendAddressesToWebhook(
+        webhookID: string,
+        newAccountAddresses: string[]
+    ): Promise<Webhook> {
         try {
             const webhook = await this.getWebhookByID(webhookID);
-            const accountAddresses = webhook.accountAddresses.concat(newAccountAddresses)
+            const accountAddresses =
+                webhook.accountAddresses.concat(newAccountAddresses);
             webhook.accountAddresses = accountAddresses;
             if (accountAddresses.length > 100_000) {
-                throw new Error(`a single webhook cannot contain more than 100,000 addresses`)
+                throw new Error(
+                    `a single webhook cannot contain more than 100,000 addresses`
+                );
             }
+            const editRequest: Partial<Webhook> = {
+                ...webhook,
+            };
+            delete editRequest["webhookID"];
+            delete editRequest["wallet"];
 
-            const { data } = await axios.put(`${API_URL_V0}/webhooks/${webhookID}?api-key=${this.apiKey}`, { ...webhook })
+            const { data } = await axios.put(
+                `${API_URL_V0}/webhooks/${webhookID}?api-key=${this.apiKey}`,
+                editRequest
+            );
             return data;
         } catch (err: any | AxiosError) {
             if (axios.isAxiosError(err)) {
-                throw new Error(`error during appendAddressesToWebhook: ${err.response?.data.error || err}`)
+                throw new Error(
+                    `error during appendAddressesToWebhook: ${
+                        err.response?.data.error || err
+                    }`
+                );
             } else {
-                throw new Error(`error during appendAddressesToWebhook: ${err}`)
+                throw new Error(
+                    `error during appendAddressesToWebhook: ${err}`
+                );
             }
         }
     }
 
-    async createCollectionWebhook(request: CreateCollectionWebhookRequest): Promise<Webhook> {
+    async createCollectionWebhook(
+        request: CreateCollectionWebhookRequest
+    ): Promise<Webhook> {
         if (request?.collectionQuery == undefined) {
-            throw new Error(`must provide collectionQuery object.`)
+            throw new Error(`must provide collectionQuery object.`);
         }
 
-        const { firstVerifiedCreators, verifiedCollectionAddresses } = request.collectionQuery;
-        if (firstVerifiedCreators != undefined && verifiedCollectionAddresses != undefined) {
-            throw new Error(`cannot provide both firstVerifiedCreators and verifiedCollectionAddresses. Please only provide one.`)
+        const { firstVerifiedCreators, verifiedCollectionAddresses } =
+            request.collectionQuery;
+        if (
+            firstVerifiedCreators != undefined &&
+            verifiedCollectionAddresses != undefined
+        ) {
+            throw new Error(
+                `cannot provide both firstVerifiedCreators and verifiedCollectionAddresses. Please only provide one.`
+            );
         }
 
         let mintlist: MintlistItem[] = [];
         let query = {};
 
         if (firstVerifiedCreators != undefined) {
-            query = { firstVerifiedCreators }
-        } else { // must have used verifiedCollectionAddresses
-            query = { verifiedCollectionAddresses }
+            query = { firstVerifiedCreators };
+        } else {
+            // must have used verifiedCollectionAddresses
+            query = { verifiedCollectionAddresses };
         }
 
         try {
             let mints = await this.getMintlist({
                 query,
                 options: {
-                    limit: 10000
-                }
-            })
-            mintlist.push(...mints.result)
+                    limit: 10000,
+                },
+            });
+            mintlist.push(...mints.result);
 
             while (mints.paginationToken) {
                 mints = await this.getMintlist({
                     query: {
-                        firstVerifiedCreators
+                        firstVerifiedCreators,
                     },
                     options: {
                         limit: 10000,
-                        paginationToken: mints.paginationToken
-                    }
-                })
-                mintlist.push(...mints.result)
+                        paginationToken: mints.paginationToken,
+                    },
+                });
+                mintlist.push(...mints.result);
             }
 
-            const { webhookURL, transactionTypes, authHeader, webhookType } = request;
-            const payload: CreateWebhookRequest = { webhookURL, accountAddresses: mintlist.map(x => x.mint), transactionTypes };
-            if (authHeader) { payload["authHeader"] = authHeader }
-            if (webhookType) { payload["webhookType"] = webhookType }
+            const { webhookURL, transactionTypes, authHeader, webhookType } =
+                request;
+            const payload: CreateWebhookRequest = {
+                webhookURL,
+                accountAddresses: mintlist.map((x) => x.mint),
+                transactionTypes,
+            };
+            if (authHeader) {
+                payload["authHeader"] = authHeader;
+            }
+            if (webhookType) {
+                payload["webhookType"] = webhookType;
+            }
 
-            return await this.createWebhook({ ...payload })
+            return await this.createWebhook({ ...payload });
         } catch (err: any | AxiosError) {
             if (axios.isAxiosError(err)) {
-                throw new Error(`error during createCollectionWebhook: ${err.response?.data.error || err}`)
+                throw new Error(
+                    `error during createCollectionWebhook: ${
+                        err.response?.data.error || err
+                    }`
+                );
             } else {
-                throw new Error(`error during createCollectionWebhook: ${err}`)
+                throw new Error(`error during createCollectionWebhook: ${err}`);
             }
         }
     }
 
     async getMintlist(request: MintlistRequest): Promise<MintlistResponse> {
         if (request?.query == undefined) {
-            throw new Error(`must provide query object.`)
+            throw new Error(`must provide query object.`);
         }
 
-        const { firstVerifiedCreators, verifiedCollectionAddresses } = request.query;
-        if (firstVerifiedCreators != undefined && verifiedCollectionAddresses != undefined) {
-            throw new Error(`cannot provide both firstVerifiedCreators and verifiedCollectionAddresses. Please only provide one.`)
+        const { firstVerifiedCreators, verifiedCollectionAddresses } =
+            request.query;
+        if (
+            firstVerifiedCreators != undefined &&
+            verifiedCollectionAddresses != undefined
+        ) {
+            throw new Error(
+                `cannot provide both firstVerifiedCreators and verifiedCollectionAddresses. Please only provide one.`
+            );
         }
 
         try {
-            const { data } = await axios.post(`${API_URL_V1}/mintlist?api-key=${this.apiKey}`, { ...request });
+            const { data } = await axios.post(
+                `${API_URL_V1}/mintlist?api-key=${this.apiKey}`,
+                { ...request }
+            );
             return data;
         } catch (err: any | AxiosError) {
             if (axios.isAxiosError(err)) {
-                throw new Error(`error during getMintlist: ${err.response?.data.error || err}`)
+                throw new Error(
+                    `error during getMintlist: ${
+                        err.response?.data.error || err
+                    }`
+                );
             } else {
-                throw new Error(`error during getMintlist: ${err}`)
+                throw new Error(`error during getMintlist: ${err}`);
             }
         }
     }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -6,13 +6,13 @@ import type {
     TransactionType,
     Source,
     ProgramName,
-    TransactionContext
-} from "./enums"
+    TransactionContext,
+} from "./enums";
 
 export type HeliusOptions = {
     limit?: number;
     paginationToken?: string;
-}
+};
 
 export interface Webhook {
     webhookID: string;
@@ -27,10 +27,10 @@ export interface Webhook {
 export type CollectionIdentifier = {
     firstVerifiedCreators?: string[];
     verifiedCollectionAddresses?: string[];
-}
+};
 
-export type CreateWebhookRequest = Omit<Webhook, 'webhookID' | 'wallet'>;
-export type EditWebhookRequest = Omit<Webhook, 'webhookID' | 'wallet'>;
+export type CreateWebhookRequest = Omit<Webhook, "webhookID" | "wallet">;
+export type EditWebhookRequest = Partial<Omit<Webhook, "webhookID" | "wallet">>;
 
 export interface CreateCollectionWebhookRequest extends CreateWebhookRequest {
     collectionQuery: CollectionIdentifier;
@@ -44,7 +44,7 @@ export interface MintlistResponse {
 export type MintlistRequest = {
     query: CollectionIdentifier;
     options?: HeliusOptions;
-}
+};
 
 export interface MintlistItem {
     mint: string;
@@ -102,7 +102,7 @@ export type InnerInstruction = {
     accounts: string[];
     data: string;
     programId: string;
-}
+};
 
 export interface ProgramInfo {
     source: Source;


### PR DESCRIPTION
All operations using the edit api are failing because we pass in the wallet and webhookID into the body.

This pr removes those fields from the object, and also makes all edit request params optional, since the remaining fields are populated from the original webhook config.

The diff is unusually large due to prettier formatting.