### PR TITLE
chore: add new readonly Helius properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ After installing, you can simply import the SDK:
 ```ts
 import { Helius } from "helius-sdk";
 
-const heliusAPI = new Helius("<your-api-key-here>"); // input your api key generated from dev.helius.xyz here
+const helius = new Helius("<your-api-key-here>"); // input your api key generated from dev.helius.xyz here
 ```
 
 **IMPORTANT:** You must generate an API key at [dev.helius.xyz](dev.helius.xyz) and replace "\<your-api-key-here>" above with it. This will take no longer than 10 seconds as we auto-generate a key for you upon connecting your wallet.
@@ -53,9 +53,9 @@ import {
     Helius,
 } from "helius-sdk";
 
-const heliusAPI = new Helius("<your-api-key-here>");
+const helius = new Helius("<your-api-key-here>");
 
-heliusAPI.createWebhook({
+helius.createWebhook({
   accountAddresses: [Address.MAGIC_EDEN_V2],
   transactionTypes: [TransactionType.NFT_LISTING],
   webhookURL: "my-webhook-handler.com/handle",
@@ -74,9 +74,9 @@ import {
   Helius
 } from "helius-sdk";
 
-const heliusAPI = new Helius("<your-api-key-here>");
+const helius = new Helius("<your-api-key-here>");
 
-heliusAPI.createWebhook({
+helius.createWebhook({
   accountAddresses: [Address.MAGIC_EDEN_V2],
   authHeader: "some auth header",
   webhookURL: "my-webhook-handler.com/handle",
@@ -94,9 +94,9 @@ You can also edit your webhooks. A common use case is dynamically adding/removin
 ```ts
 import { Helius, Address } from "helius-sdk";
 
-const heliusAPI = new Helius("<your-api-key-here>");
+const helius = new Helius("<your-api-key-here>");
 
-heliusAPI.editWebhook(
+helius.editWebhook(
   "your-webhook-id-here",
   { accountAddresses: [Address.SQUADS] } // This will ONLY update accountAddresses, not the other fields on the webhook object
 );
@@ -110,9 +110,9 @@ For convenience, we've added a method to let you simply append new addresses to 
 ```ts
 import { Helius, Address } from "helius-sdk";
 
-const heliusAPI = new Helius("<your-api-key-here>");
+const helius = new Helius("<your-api-key-here>");
 
-heliusAPI.appendAddressesToWebhook("your-webhook-id-here", [
+helius.appendAddressesToWebhook("your-webhook-id-here", [
   Address.SQUADS,
   Address.JUPITER_V3,
 ]);
@@ -123,9 +123,9 @@ heliusAPI.appendAddressesToWebhook("your-webhook-id-here", [
 ```ts
 import { Helius } from "helius-sdk";
 
-const heliusAPI = new Helius("<your-api-key-here>");
+const helius = new Helius("<your-api-key-here>");
 
-heliusAPI.getAllWebhooks();
+helius.getAllWebhooks();
 ```
 
 ### **Get A Single Webhook**
@@ -133,9 +133,9 @@ heliusAPI.getAllWebhooks();
 ```ts
 import { Helius } from "helius-sdk";
 
-const heliusAPI = new Helius("<your-api-key-here>");
+const helius = new Helius("<your-api-key-here>");
 
-heliusAPI.getWebhookByID("<webhook-id-here>");
+helius.getWebhookByID("<webhook-id-here>");
 ```
 
 ### **Delete a Webhook**
@@ -143,9 +143,9 @@ heliusAPI.getWebhookByID("<webhook-id-here>");
 ```ts
 import { Helius } from "helius-sdk";
 
-const heliusAPI = new Helius("<your-api-key-here>");
+const helius = new Helius("<your-api-key-here>");
 
-heliusAPI.deleteWebhook("<webhook-id-here>"); // returns a boolean
+helius.deleteWebhook("<webhook-id-here>"); // returns a boolean
 ```
 
 ### **Collection Webhooks!**
@@ -158,9 +158,9 @@ import {
   Helius,
 } from "helius-sdk";
 
-const heliusAPI = new Helius("<your-api-key-here>");
+const helius = new Helius("<your-api-key-here>");
 
-heliusAPI.createCollectionWebhook({
+helius.createCollectionWebhook({
   collectionQuery: Collections.ABC,
   transactionTypes: [Types.TransactionType.ANY],
   webhookType: Types.WebhookType.DISCORD,
@@ -184,9 +184,9 @@ import {
   Collections,
 } from "helius-sdk";
 
-const heliusAPI = new Helius("<your-api-key-here>");
+const helius = new Helius("<your-api-key-here>");
 
-const mints = heliusAPI.getMintlist({
+const mints = helius.getMintlist({
   query: Collections.ABC,
 });
 ```
@@ -199,7 +199,16 @@ We provide a variety of helper methods to help make Solana RPCs easier to work w
 ```ts
 import { Helius } from "helius-sdk";
 
-const heliusAPI = new Helius("<your-api-key-here>");
+const helius = new Helius("<your-api-key-here>");
 
-const tps = await heliusAPI.getCurrentTPS();
+const tps = await helius.rpc.getCurrentTPS();
+```
+
+### Solana Airdrop
+```ts
+import { Helius } from "helius-sdk";
+
+const helius = new Helius("<your-api-key-here>");
+
+const response = await helius.rpc.airdrop(1000000000); // 1 sol
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "helius-sdk",
-  "version": "0.2.5",
+  "version": "0.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "helius-sdk",
-      "version": "0.2.5",
+      "version": "0.4.1",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.2.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helius-sdk",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "SDK for the Helius API (https://helius.xyz)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/Helius.ts
+++ b/src/Helius.ts
@@ -1,11 +1,11 @@
 import {
-    Webhook,
-    CreateWebhookRequest,
-    EditWebhookRequest,
-    CreateCollectionWebhookRequest,
-    MintlistRequest,
-    MintlistResponse,
-    MintlistItem,
+  Webhook,
+  CreateWebhookRequest,
+  EditWebhookRequest,
+  CreateCollectionWebhookRequest,
+  MintlistRequest,
+  MintlistResponse,
+  MintlistItem,
 } from "./types";
 
 import axios, { type AxiosError } from "axios";
@@ -21,347 +21,339 @@ const API_URL_V1: string = "https://api.helius.xyz/v1";
  * @class
  */
 export class Helius {
-    /**
-     * API key generated at dev.helius.xyz
-     * @private
-     */
-    private apiKey: string;
+  /**
+   * API key generated at dev.helius.xyz
+   * @private
+   */
+  private apiKey: string;
 
-    /** The cluster in which the connection endpoint belongs to */
-    public readonly cluster: Cluster;
+  /** The cluster in which the connection endpoint belongs to */
+  public readonly cluster: Cluster;
 
-    /** URL to the fullnode JSON RPC endpoint */
-    public readonly endpoint: string;
+  /** URL to the fullnode JSON RPC endpoint */
+  public readonly endpoint: string;
 
-    /** The connection object from Solana's SDK */
-    public readonly connection: Connection;
+  /** The connection object from Solana's SDK */
+  public readonly connection: Connection;
 
-    /** The beefed up rpc client object from Helius SDK */
-    public readonly rpc: RpcClient;
+  /** The beefed up rpc client object from Helius SDK */
+  public readonly rpc: RpcClient;
 
-    /**
-     * Initializes Helius API client with an API key
-     * @constructor
-     * @param apiKey - API key generated at dev.helius.xyz
-     */
-    constructor(apiKey: string, cluster: Cluster = "mainnet-beta") {
-        this.apiKey = apiKey;
-        this.cluster = cluster;
-        this.endpoint = heliusClusterApiUrl(apiKey, cluster)
-        this.connection = new Connection(this.endpoint)
-        this.rpc = new RpcClient(this.connection)
-    }
+  /**
+   * Initializes Helius API client with an API key
+   * @constructor
+   * @param apiKey - API key generated at dev.helius.xyz
+   */
+  constructor(apiKey: string, cluster: Cluster = "mainnet-beta") {
+    this.apiKey = apiKey;
+    this.cluster = cluster;
+    this.endpoint = heliusClusterApiUrl(apiKey, cluster);
+    this.connection = new Connection(this.endpoint);
+    this.rpc = new RpcClient(this.connection);
+  }
 
-    /**
-     * Retrieves a list of all webhooks associated with the current API key
-     * @returns {Promise<Webhook[]>} a promise that resolves to an array of webhook objects
-     * @throws {Error} if there is an error calling the webhooks endpoint or if the response contains an error
-     */
-    async getAllWebhooks(): Promise<Webhook[]> {
-        try {
-            const { data } = await axios.get(
-                `${API_URL_V0}/webhooks?api-key=${this.apiKey}`
-            );
-            return data;
-        } catch (err: any | AxiosError) {
-            if (axios.isAxiosError(err)) {
-                throw new Error(
-                    `error calling getWebhooks: ${err.response?.data.error || err
-                    }`
-                );
-            } else {
-                throw new Error(`error calling getWebhooks: ${err}`);
-            }
-        }
-    }
-
-    /**
-     * Retrieves a single webhook by its ID, associated with the current API key
-     * @param {string} webhookID - the ID of the webhook to retrieve
-     * @returns {Promise<Webhook>} a promise that resolves to a webhook object
-     * @throws {Error} if there is an error calling the webhooks endpoint or if the response contains an error
-     */
-    async getWebhookByID(webhookID: string): Promise<Webhook> {
-        try {
-            const { data } = await axios.get(
-                `${API_URL_V0}/webhooks/${webhookID}?api-key=${this.apiKey}`
-            );
-            return data;
-        } catch (err: any | AxiosError) {
-            if (axios.isAxiosError(err)) {
-                throw new Error(
-                    `error during getWebhookByID: ${err.response?.data.error || err
-                    }`
-                );
-            } else {
-                throw new Error(`error during getWebhookByID: ${err}`);
-            }
-        }
-    }
-
-    /**
-     * Creates a new webhook with the provided request
-     * @param {CreateWebhookRequest} createWebhookRequest - the request object containing the webhook information
-     * @returns {Promise<Webhook>} a promise that resolves to the created webhook object
-     * @throws {Error} if there is an error calling the webhooks endpoint or if the response contains an error
-     */
-    async createWebhook(
-        createWebhookRequest: CreateWebhookRequest
-    ): Promise<Webhook> {
-        const addressesOffCurve = createWebhookRequest.accountAddresses.filter(
-            (address) => !PublicKey.isOnCurve(address)
+  /**
+   * Retrieves a list of all webhooks associated with the current API key
+   * @returns {Promise<Webhook[]>} a promise that resolves to an array of webhook objects
+   * @throws {Error} if there is an error calling the webhooks endpoint or if the response contains an error
+   */
+  async getAllWebhooks(): Promise<Webhook[]> {
+    try {
+      const { data } = await axios.get(
+        `${API_URL_V0}/webhooks?api-key=${this.apiKey}`
+      );
+      return data;
+    } catch (err: any | AxiosError) {
+      if (axios.isAxiosError(err)) {
+        throw new Error(
+          `error calling getWebhooks: ${err.response?.data.error || err}`
         );
-        if (addressesOffCurve.length > 0) {
-            throw new Error(
-                `bad 'accountAddresses' parameter, addresses [${addressesOffCurve.toString()}] are invalid`
-            );
-        }
+      } else {
+        throw new Error(`error calling getWebhooks: ${err}`);
+      }
+    }
+  }
 
-        try {
-            const { data } = await axios.post(
-                `${API_URL_V0}/webhooks?api-key=${this.apiKey}`,
-                { ...createWebhookRequest }
-            );
-            return data;
-        } catch (err: any | AxiosError) {
-            if (axios.isAxiosError(err)) {
-                throw new Error(
-                    `error during createWebhook: ${err.response?.data.error || err
-                    }`
-                );
-            } else {
-                throw new Error(`error during createWebhook: ${err}`);
-            }
-        }
+  /**
+   * Retrieves a single webhook by its ID, associated with the current API key
+   * @param {string} webhookID - the ID of the webhook to retrieve
+   * @returns {Promise<Webhook>} a promise that resolves to a webhook object
+   * @throws {Error} if there is an error calling the webhooks endpoint or if the response contains an error
+   */
+  async getWebhookByID(webhookID: string): Promise<Webhook> {
+    try {
+      const { data } = await axios.get(
+        `${API_URL_V0}/webhooks/${webhookID}?api-key=${this.apiKey}`
+      );
+      return data;
+    } catch (err: any | AxiosError) {
+      if (axios.isAxiosError(err)) {
+        throw new Error(
+          `error during getWebhookByID: ${err.response?.data.error || err}`
+        );
+      } else {
+        throw new Error(`error during getWebhookByID: ${err}`);
+      }
+    }
+  }
+
+  /**
+   * Creates a new webhook with the provided request
+   * @param {CreateWebhookRequest} createWebhookRequest - the request object containing the webhook information
+   * @returns {Promise<Webhook>} a promise that resolves to the created webhook object
+   * @throws {Error} if there is an error calling the webhooks endpoint or if the response contains an error
+   */
+  async createWebhook(
+    createWebhookRequest: CreateWebhookRequest
+  ): Promise<Webhook> {
+    const addressesOffCurve = createWebhookRequest.accountAddresses.filter(
+      (address) => !PublicKey.isOnCurve(address)
+    );
+    if (addressesOffCurve.length > 0) {
+      throw new Error(
+        `bad 'accountAddresses' parameter, addresses [${addressesOffCurve.toString()}] are invalid`
+      );
     }
 
-    /**
-     * Deletes a webhook by its ID
-     * @param {string} webhookID - the ID of the webhook to delete
-     * @returns {Promise<boolean>} a promise that resolves to true if the webhook was successfully deleted, or false otherwise
-     * @throws {Error} if there is an error calling the webhooks endpoint or if the response contains an error
-     */
-    async deleteWebhook(webhookID: string): Promise<boolean> {
-        try {
-            await axios.delete(
-                `${API_URL_V0}/webhooks/${webhookID}?api-key=${this.apiKey}`
-            );
-            return true;
-        } catch (err: any | AxiosError) {
-            if (axios.isAxiosError(err)) {
-                throw new Error(
-                    `error during deleteWebhook: ${err.response?.data.error || err
-                    }`
-                );
-            } else {
-                throw new Error(`error during deleteWebhook: ${err}`);
-            }
-        }
+    try {
+      const { data } = await axios.post(
+        `${API_URL_V0}/webhooks?api-key=${this.apiKey}`,
+        { ...createWebhookRequest }
+      );
+      return data;
+    } catch (err: any | AxiosError) {
+      if (axios.isAxiosError(err)) {
+        throw new Error(
+          `error during createWebhook: ${err.response?.data.error || err}`
+        );
+      } else {
+        throw new Error(`error during createWebhook: ${err}`);
+      }
+    }
+  }
+
+  /**
+   * Deletes a webhook by its ID
+   * @param {string} webhookID - the ID of the webhook to delete
+   * @returns {Promise<boolean>} a promise that resolves to true if the webhook was successfully deleted, or false otherwise
+   * @throws {Error} if there is an error calling the webhooks endpoint or if the response contains an error
+   */
+  async deleteWebhook(webhookID: string): Promise<boolean> {
+    try {
+      await axios.delete(
+        `${API_URL_V0}/webhooks/${webhookID}?api-key=${this.apiKey}`
+      );
+      return true;
+    } catch (err: any | AxiosError) {
+      if (axios.isAxiosError(err)) {
+        throw new Error(
+          `error during deleteWebhook: ${err.response?.data.error || err}`
+        );
+      } else {
+        throw new Error(`error during deleteWebhook: ${err}`);
+      }
+    }
+  }
+
+  /**
+   * Edits an existing webhook by its ID with the provided request
+   * @param {string} webhookID - the ID of the webhook to edit
+   * @param {EditWebhookRequest} editWebhookRequest - the request object containing the webhook information
+   * @returns {Promise<Webhook>} a promise that resolves to the edited webhook object
+   * @throws {Error} if there is an error calling the webhooks endpoint or if the response contains an error
+   */
+  async editWebhook(
+    webhookID: string,
+    editWebhookRequest: EditWebhookRequest
+  ): Promise<Webhook> {
+    if (editWebhookRequest.accountAddresses) {
+      const addressesOffCurve = editWebhookRequest.accountAddresses.filter(
+        (address) => !PublicKey.isOnCurve(address)
+      );
+      if (addressesOffCurve.length > 0) {
+        throw new Error(
+          `bad 'accountAddresses' parameter, addresses [${addressesOffCurve.toString()}] are invalid`
+        );
+      }
     }
 
-    /**
-     * Edits an existing webhook by its ID with the provided request
-     * @param {string} webhookID - the ID of the webhook to edit
-     * @param {EditWebhookRequest} editWebhookRequest - the request object containing the webhook information
-     * @returns {Promise<Webhook>} a promise that resolves to the edited webhook object
-     * @throws {Error} if there is an error calling the webhooks endpoint or if the response contains an error
-     */
-    async editWebhook(
-        webhookID: string,
-        editWebhookRequest: EditWebhookRequest
-    ): Promise<Webhook> {
-        if (editWebhookRequest.accountAddresses) {
-            const addressesOffCurve =
-                editWebhookRequest.accountAddresses.filter(
-                    (address) => !PublicKey.isOnCurve(address)
-                );
-            if (addressesOffCurve.length > 0) {
-                throw new Error(
-                    `bad 'accountAddresses' parameter, addresses [${addressesOffCurve.toString()}] are invalid`
-                );
-            }
-        }
+    try {
+      const webhook = await this.getWebhookByID(webhookID);
+      const editRequest: Partial<Webhook> = {
+        ...webhook,
+        ...editWebhookRequest,
+      };
+      delete editRequest["webhookID"];
+      delete editRequest["wallet"];
 
-        try {
-            const webhook = await this.getWebhookByID(webhookID);
-            const editRequest: Partial<Webhook> = {
-                ...webhook,
-                ...editWebhookRequest,
-            };
-            delete editRequest["webhookID"];
-            delete editRequest["wallet"];
+      const { data } = await axios.put(
+        `${API_URL_V0}/webhooks/${webhookID}?api-key=${this.apiKey}`,
+        editRequest
+      );
+      return data;
+    } catch (err: any | AxiosError) {
+      if (axios.isAxiosError(err)) {
+        throw new Error(
+          `error during editWebhook: ${err.response?.data.error || err}`
+        );
+      } else {
+        throw new Error(`error during editWebhook: ${err}`);
+      }
+    }
+  }
 
-            const { data } = await axios.put(
-                `${API_URL_V0}/webhooks/${webhookID}?api-key=${this.apiKey}`,
-                editRequest
-            );
-            return data;
-        } catch (err: any | AxiosError) {
-            if (axios.isAxiosError(err)) {
-                throw new Error(
-                    `error during editWebhook: ${err.response?.data.error || err
-                    }`
-                );
-            } else {
-                throw new Error(`error during editWebhook: ${err}`);
-            }
-        }
+  /**
+   * Appends an array of addresses to an existing webhook by its ID
+   * @param {string} webhookID - the ID of the webhook to edit
+   * @param {string[]} newAccountAddresses - the array of addresses to be added to the webhook
+   * @returns {Promise<Webhook>} a promise that resolves to the edited webhook object
+   * @throws {Error} if there is an error calling the webhooks endpoint, if the response contains an error, or if the number of addresses exceeds 10,000
+   */
+  async appendAddressesToWebhook(
+    webhookID: string,
+    newAccountAddresses: string[]
+  ): Promise<Webhook> {
+    try {
+      const webhook = await this.getWebhookByID(webhookID);
+      const accountAddresses =
+        webhook.accountAddresses.concat(newAccountAddresses);
+      webhook.accountAddresses = accountAddresses;
+      if (accountAddresses.length > 100_000) {
+        throw new Error(
+          `a single webhook cannot contain more than 100,000 addresses`
+        );
+      }
+      const editRequest: Partial<Webhook> = {
+        ...webhook,
+      };
+      delete editRequest["webhookID"];
+      delete editRequest["wallet"];
+
+      const { data } = await axios.put(
+        `${API_URL_V0}/webhooks/${webhookID}?api-key=${this.apiKey}`,
+        editRequest
+      );
+      return data;
+    } catch (err: any | AxiosError) {
+      if (axios.isAxiosError(err)) {
+        throw new Error(
+          `error during appendAddressesToWebhook: ${
+            err.response?.data.error || err
+          }`
+        );
+      } else {
+        throw new Error(`error during appendAddressesToWebhook: ${err}`);
+      }
+    }
+  }
+
+  async createCollectionWebhook(
+    request: CreateCollectionWebhookRequest
+  ): Promise<Webhook> {
+    if (request?.collectionQuery == undefined) {
+      throw new Error(`must provide collectionQuery object.`);
     }
 
-    /**
-     * Appends an array of addresses to an existing webhook by its ID
-     * @param {string} webhookID - the ID of the webhook to edit
-     * @param {string[]} newAccountAddresses - the array of addresses to be added to the webhook
-     * @returns {Promise<Webhook>} a promise that resolves to the edited webhook object
-     * @throws {Error} if there is an error calling the webhooks endpoint, if the response contains an error, or if the number of addresses exceeds 10,000
-     */
-    async appendAddressesToWebhook(
-        webhookID: string,
-        newAccountAddresses: string[]
-    ): Promise<Webhook> {
-        try {
-            const webhook = await this.getWebhookByID(webhookID);
-            const accountAddresses =
-                webhook.accountAddresses.concat(newAccountAddresses);
-            webhook.accountAddresses = accountAddresses;
-            if (accountAddresses.length > 100_000) {
-                throw new Error(
-                    `a single webhook cannot contain more than 100,000 addresses`
-                );
-            }
-            const editRequest: Partial<Webhook> = {
-                ...webhook,
-            };
-            delete editRequest["webhookID"];
-            delete editRequest["wallet"];
-
-            const { data } = await axios.put(
-                `${API_URL_V0}/webhooks/${webhookID}?api-key=${this.apiKey}`,
-                editRequest
-            );
-            return data;
-        } catch (err: any | AxiosError) {
-            if (axios.isAxiosError(err)) {
-                throw new Error(
-                    `error during appendAddressesToWebhook: ${err.response?.data.error || err
-                    }`
-                );
-            } else {
-                throw new Error(
-                    `error during appendAddressesToWebhook: ${err}`
-                );
-            }
-        }
+    const { firstVerifiedCreators, verifiedCollectionAddresses } =
+      request.collectionQuery;
+    if (
+      firstVerifiedCreators != undefined &&
+      verifiedCollectionAddresses != undefined
+    ) {
+      throw new Error(
+        `cannot provide both firstVerifiedCreators and verifiedCollectionAddresses. Please only provide one.`
+      );
     }
 
-    async createCollectionWebhook(
-        request: CreateCollectionWebhookRequest
-    ): Promise<Webhook> {
-        if (request?.collectionQuery == undefined) {
-            throw new Error(`must provide collectionQuery object.`);
-        }
+    let mintlist: MintlistItem[] = [];
+    let query = {};
 
-        const { firstVerifiedCreators, verifiedCollectionAddresses } =
-            request.collectionQuery;
-        if (
-            firstVerifiedCreators != undefined &&
-            verifiedCollectionAddresses != undefined
-        ) {
-            throw new Error(
-                `cannot provide both firstVerifiedCreators and verifiedCollectionAddresses. Please only provide one.`
-            );
-        }
-
-        let mintlist: MintlistItem[] = [];
-        let query = {};
-
-        if (firstVerifiedCreators != undefined) {
-            query = { firstVerifiedCreators };
-        } else {
-            // must have used verifiedCollectionAddresses
-            query = { verifiedCollectionAddresses };
-        }
-
-        try {
-            let mints = await this.getMintlist({
-                query,
-                options: {
-                    limit: 10000,
-                },
-            });
-            mintlist.push(...mints.result);
-
-            while (mints.paginationToken) {
-                mints = await this.getMintlist({
-                    query: {
-                        firstVerifiedCreators,
-                    },
-                    options: {
-                        limit: 10000,
-                        paginationToken: mints.paginationToken,
-                    },
-                });
-                mintlist.push(...mints.result);
-            }
-
-            const { webhookURL, transactionTypes, authHeader, webhookType } =
-                request;
-            const payload: CreateWebhookRequest = {
-                webhookURL,
-                accountAddresses: mintlist.map((x) => x.mint),
-                transactionTypes,
-            };
-            if (authHeader) {
-                payload["authHeader"] = authHeader;
-            }
-            if (webhookType) {
-                payload["webhookType"] = webhookType;
-            }
-
-            return await this.createWebhook({ ...payload });
-        } catch (err: any | AxiosError) {
-            if (axios.isAxiosError(err)) {
-                throw new Error(
-                    `error during createCollectionWebhook: ${err.response?.data.error || err
-                    }`
-                );
-            } else {
-                throw new Error(`error during createCollectionWebhook: ${err}`);
-            }
-        }
+    if (firstVerifiedCreators != undefined) {
+      query = { firstVerifiedCreators };
+    } else {
+      // must have used verifiedCollectionAddresses
+      query = { verifiedCollectionAddresses };
     }
 
-    async getMintlist(request: MintlistRequest): Promise<MintlistResponse> {
-        if (request?.query == undefined) {
-            throw new Error(`must provide query object.`);
-        }
+    try {
+      let mints = await this.getMintlist({
+        query,
+        options: {
+          limit: 10000,
+        },
+      });
+      mintlist.push(...mints.result);
 
-        const { firstVerifiedCreators, verifiedCollectionAddresses } =
-            request.query;
-        if (
-            firstVerifiedCreators != undefined &&
-            verifiedCollectionAddresses != undefined
-        ) {
-            throw new Error(
-                `cannot provide both firstVerifiedCreators and verifiedCollectionAddresses. Please only provide one.`
-            );
-        }
+      while (mints.paginationToken) {
+        mints = await this.getMintlist({
+          query: {
+            firstVerifiedCreators,
+          },
+          options: {
+            limit: 10000,
+            paginationToken: mints.paginationToken,
+          },
+        });
+        mintlist.push(...mints.result);
+      }
 
-        try {
-            const { data } = await axios.post(
-                `${API_URL_V1}/mintlist?api-key=${this.apiKey}`,
-                { ...request }
-            );
-            return data;
-        } catch (err: any | AxiosError) {
-            if (axios.isAxiosError(err)) {
-                throw new Error(
-                    `error during getMintlist: ${err.response?.data.error || err
-                    }`
-                );
-            } else {
-                throw new Error(`error during getMintlist: ${err}`);
-            }
-        }
+      const { webhookURL, transactionTypes, authHeader, webhookType } = request;
+      const payload: CreateWebhookRequest = {
+        webhookURL,
+        accountAddresses: mintlist.map((x) => x.mint),
+        transactionTypes,
+      };
+      if (authHeader) {
+        payload["authHeader"] = authHeader;
+      }
+      if (webhookType) {
+        payload["webhookType"] = webhookType;
+      }
+
+      return await this.createWebhook({ ...payload });
+    } catch (err: any | AxiosError) {
+      if (axios.isAxiosError(err)) {
+        throw new Error(
+          `error during createCollectionWebhook: ${
+            err.response?.data.error || err
+          }`
+        );
+      } else {
+        throw new Error(`error during createCollectionWebhook: ${err}`);
+      }
     }
+  }
+
+  async getMintlist(request: MintlistRequest): Promise<MintlistResponse> {
+    if (request?.query == undefined) {
+      throw new Error(`must provide query object.`);
+    }
+
+    const { firstVerifiedCreators, verifiedCollectionAddresses } =
+      request.query;
+    if (
+      firstVerifiedCreators != undefined &&
+      verifiedCollectionAddresses != undefined
+    ) {
+      throw new Error(
+        `cannot provide both firstVerifiedCreators and verifiedCollectionAddresses. Please only provide one.`
+      );
+    }
+
+    try {
+      const { data } = await axios.post(
+        `${API_URL_V1}/mintlist?api-key=${this.apiKey}`,
+        { ...request }
+      );
+      return data;
+    } catch (err: any | AxiosError) {
+      if (axios.isAxiosError(err)) {
+        throw new Error(
+          `error during getMintlist: ${err.response?.data.error || err}`
+        );
+      } else {
+        throw new Error(`error during getMintlist: ${err}`);
+      }
+    }
+  }
 }

--- a/src/RpcClient.ts
+++ b/src/RpcClient.ts
@@ -1,0 +1,73 @@
+import {
+    BlockhashWithExpiryBlockHeight,
+    TransactionSignature,
+    Commitment,
+    PublicKey,
+    GetLatestBlockhashConfig,
+    RpcResponseAndContext,
+    SignatureResult,
+    Blockhash,
+    Connection,
+} from "@solana/web3.js";
+
+export type SendAndConfirmTransactionResponse = {
+    signature: TransactionSignature;
+    confirmResponse: RpcResponseAndContext<SignatureResult>;
+    blockhash: Blockhash;
+    lastValidBlockHeight: number;
+};
+
+export class RpcClient {
+    constructor(protected readonly connection: Connection) { }
+
+    /**
+     * Request an allocation of lamports to the specified address
+     * @returns {Promise<SendAndConfirmTransactionResponse>}
+     */
+    async airdrop(
+        publicKey: PublicKey,
+        lamports: number,
+        commitment?: Commitment
+    ): Promise<SendAndConfirmTransactionResponse> {
+        const signature = await this.connection.requestAirdrop(
+            publicKey,
+            lamports
+        );
+
+        const blockhashWithExpiryBlockHeight = await this.getLatestBlockhash();
+        const confirmResponse = await this.connection.confirmTransaction(
+            {
+                signature,
+                ...blockhashWithExpiryBlockHeight,
+            },
+            commitment
+        );
+
+        return { signature, confirmResponse, ...blockhashWithExpiryBlockHeight };
+    }
+
+    /**
+     * Fetch the latest blockhash from the cluster
+     * @returns {Promise<BlockhashWithExpiryBlockHeight>}
+    */
+    async getLatestBlockhash(
+        commitmentOrConfig: Commitment | GetLatestBlockhashConfig = 'finalized'
+    ): Promise<BlockhashWithExpiryBlockHeight> {
+        return this.connection.getLatestBlockhash(commitmentOrConfig);
+    }
+
+    /**
+    * Returns the current transactions per second (TPS) rate — including voting transactions.
+    *
+    * @returns {Promise<number>} A promise that resolves to the current TPS rate.
+    * @throws {Error} If there was an error calling the `getRecentPerformanceSamples` method.
+    */
+    async getCurrentTPS(): Promise<number> {
+        try {
+            const samples = await this.connection.getRecentPerformanceSamples(1)
+            return samples[0]?.numTransactions / samples[0]?.samplePeriodSecs
+        } catch (e) {
+            throw new Error(`error calling getCurrentTPS: ${e}`)
+        }
+    }
+}

--- a/src/RpcClient.ts
+++ b/src/RpcClient.ts
@@ -1,73 +1,70 @@
 import {
-    BlockhashWithExpiryBlockHeight,
-    TransactionSignature,
-    Commitment,
-    PublicKey,
-    GetLatestBlockhashConfig,
-    RpcResponseAndContext,
-    SignatureResult,
-    Blockhash,
-    Connection,
+  BlockhashWithExpiryBlockHeight,
+  TransactionSignature,
+  Commitment,
+  PublicKey,
+  GetLatestBlockhashConfig,
+  RpcResponseAndContext,
+  SignatureResult,
+  Blockhash,
+  Connection,
 } from "@solana/web3.js";
 
 export type SendAndConfirmTransactionResponse = {
-    signature: TransactionSignature;
-    confirmResponse: RpcResponseAndContext<SignatureResult>;
-    blockhash: Blockhash;
-    lastValidBlockHeight: number;
+  signature: TransactionSignature;
+  confirmResponse: RpcResponseAndContext<SignatureResult>;
+  blockhash: Blockhash;
+  lastValidBlockHeight: number;
 };
 
 export class RpcClient {
-    constructor(protected readonly connection: Connection) { }
+  constructor(protected readonly connection: Connection) {}
 
-    /**
-     * Request an allocation of lamports to the specified address
-     * @returns {Promise<SendAndConfirmTransactionResponse>}
-     */
-    async airdrop(
-        publicKey: PublicKey,
-        lamports: number,
-        commitment?: Commitment
-    ): Promise<SendAndConfirmTransactionResponse> {
-        const signature = await this.connection.requestAirdrop(
-            publicKey,
-            lamports
-        );
+  /**
+   * Request an allocation of lamports to the specified address
+   * @returns {Promise<SendAndConfirmTransactionResponse>}
+   */
+  async airdrop(
+    publicKey: PublicKey,
+    lamports: number,
+    commitment?: Commitment
+  ): Promise<SendAndConfirmTransactionResponse> {
+    const signature = await this.connection.requestAirdrop(publicKey, lamports);
 
-        const blockhashWithExpiryBlockHeight = await this.getLatestBlockhash();
-        const confirmResponse = await this.connection.confirmTransaction(
-            {
-                signature,
-                ...blockhashWithExpiryBlockHeight,
-            },
-            commitment
-        );
+    const blockhashWithExpiryBlockHeight = await this.getLatestBlockhash();
+    const confirmResponse = await this.connection.confirmTransaction(
+      {
+        signature,
+        ...blockhashWithExpiryBlockHeight,
+      },
+      commitment
+    );
 
-        return { signature, confirmResponse, ...blockhashWithExpiryBlockHeight };
+    return { signature, confirmResponse, ...blockhashWithExpiryBlockHeight };
+  }
+
+  /**
+   * Fetch the latest blockhash from the cluster
+   * @returns {Promise<BlockhashWithExpiryBlockHeight>}
+   */
+  async getLatestBlockhash(
+    commitmentOrConfig: Commitment | GetLatestBlockhashConfig = "finalized"
+  ): Promise<BlockhashWithExpiryBlockHeight> {
+    return this.connection.getLatestBlockhash(commitmentOrConfig);
+  }
+
+  /**
+   * Returns the current transactions per second (TPS) rate — including voting transactions.
+   *
+   * @returns {Promise<number>} A promise that resolves to the current TPS rate.
+   * @throws {Error} If there was an error calling the `getRecentPerformanceSamples` method.
+   */
+  async getCurrentTPS(): Promise<number> {
+    try {
+      const samples = await this.connection.getRecentPerformanceSamples(1);
+      return samples[0]?.numTransactions / samples[0]?.samplePeriodSecs;
+    } catch (e) {
+      throw new Error(`error calling getCurrentTPS: ${e}`);
     }
-
-    /**
-     * Fetch the latest blockhash from the cluster
-     * @returns {Promise<BlockhashWithExpiryBlockHeight>}
-    */
-    async getLatestBlockhash(
-        commitmentOrConfig: Commitment | GetLatestBlockhashConfig = 'finalized'
-    ): Promise<BlockhashWithExpiryBlockHeight> {
-        return this.connection.getLatestBlockhash(commitmentOrConfig);
-    }
-
-    /**
-    * Returns the current transactions per second (TPS) rate — including voting transactions.
-    *
-    * @returns {Promise<number>} A promise that resolves to the current TPS rate.
-    * @throws {Error} If there was an error calling the `getRecentPerformanceSamples` method.
-    */
-    async getCurrentTPS(): Promise<number> {
-        try {
-            const samples = await this.connection.getRecentPerformanceSamples(1)
-            return samples[0]?.numTransactions / samples[0]?.samplePeriodSecs
-        } catch (e) {
-            throw new Error(`error calling getCurrentTPS: ${e}`)
-        }
-    }
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
-export * from './types';
-export * from './Helius';
-
+export * from "./types";
+export * from "./utils";
+export * from "./Helius";
+export * from "./RpcClient";

--- a/src/utils/cluster.ts
+++ b/src/utils/cluster.ts
@@ -1,0 +1,18 @@
+import { Cluster } from "@solana/web3.js";
+
+/**
+ * Retrieves the Helius RPC API URL for the specified cluster
+ */
+export function heliusClusterApiUrl(
+  apiKey: string,
+  cluster: Cluster = "devnet"
+): string {
+  switch (cluster) {
+    case "devnet":
+      return `https://rpc-devnet.helius.xyz/?api-key=${apiKey}`;
+    case "mainnet-beta":
+      return `https://rpc.helius.xyz/?api-key=${apiKey}`;
+    default:
+      return "";
+  }
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from "./cluster";


### PR DESCRIPTION
This PR adds new readonly properties to the `Helius` class, a utility function and a new `RpcClient` class as a tooling for awesome RPC calls.

---
**Following fields were added to the `Helius` class**
```ts
public readonly cluster: Cluster;
public readonly endpoint: string;
public readonly rpc: RpcClient;

```

and existing `rpcClient` was renamed to a more appropriate name `connection`
```ts
public readonly connection: Connection;
```

---
**Following utility functions were added**
`heliusClusterApiUrl` - it's inspired by `clusterApiUrl` function from the `solana-web3.js` package

---
**Following was achieved with the `RpcClient` class**
`RpcClient` exposes 3 functions: `airdrop`, `getLatestBlockhash`, `getCurrentTPS` (migrated from the `Helius` class)

This way, SDK consumers can call awesome "enhanced" calls to RPCs in the following fashion:
```ts
await helius.rpc.airdrop(1000000000);
```
or
```ts
await helius.rpc.getCurrentTPS();
```

This change follows the convention which Metaplex has with their SDK and `metaplex.rpc()` plugin

I propose following Metaplex a bit more in terms of rpc logic and a few types/utilities. e.g. their `sol()`, and `lamport()` functions for easier handling of amounts (_notice the `airdrop(1000000000)` above_)

Honorable mention: in the documentation I have renamed the `heliusApi` variable to `helius` to better reflect the objects purpose and Class. I understand that renaming variables sometimes feels like touching people in private places, so sorry if it was inappropriate!