### PR TITLE
fix: createCollectionWebhook query params

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "helius-sdk",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "helius-sdk",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.2.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helius-sdk",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "SDK for the Helius API (https://helius.xyz)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/Helius.ts
+++ b/src/Helius.ts
@@ -286,9 +286,7 @@ export class Helius {
 
       while (mints.paginationToken) {
         mints = await this.getMintlist({
-          query: {
-            firstVerifiedCreators,
-          },
+          query,
           options: {
             limit: 10000,
             paginationToken: mints.paginationToken,


### PR DESCRIPTION
`createCollectionWebhook` is not working when fetching collections via collection NFTs since the query parameter is wrongly set to use `firstVerifiedCreators` on lines 284-286, in the while loop.

In order to replicate this error you would need to fetch a collection with more than 10000 items via collection NFT. e.g. y00ts collection on: `4mKSoDDqApmF1DqXvVTSL6tu2zixrSSNjqMxUnwvVzy2` because the issue is in the while loop which is triggered if there is pagination token present.