### PR TITLE
fix: nft event type

### DIFF
--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -140,12 +140,13 @@ export interface NFTEvent {
     seller: string;
     buyer: string;
     timestamp: number;
-    transactionAmount: number;
+    amount: number;
+    fee:number;
     signature: string;
     source: Source;
     type: TransactionType;
-    context?: TransactionContext;
-    tokensInvolved: Token[];
+    saleType?: TransactionContext;
+    nfts: Token[];
 }
 
 export interface TransactionEvent {


### PR DESCRIPTION
This PR fixes nft event type
response returned :
 ```
nft: {
      amount: 1000000000,
      buyer: '',
      description: '3dkovHUm4UJRGjtRmapGJzHjwQFPjaGiPoFjNQxPj1sS listed Rise of the Gorecats #5 for 1 SOL on METAPLEX.',
      fee: 5000,
      feePayer: '3dkovHUm4UJRGjtRmapGJzHjwQFPjaGiPoFjNQxPj1sS',
      nfts: [Array],
      saleType: 'UNKNOWN',
      seller: '3dkovHUm4UJRGjtRmapGJzHjwQFPjaGiPoFjNQxPj1sS',
      signature: '5nQaKLntqsXKLBqpAZmB6JGjpMWPszbEzUT4PuE4fTPyhyFc87sKvwDtYdiMJnujVym8oc4KUaCCtPhbhhSWAtJr',
      slot: 203451432,
      source: 'METAPLEX',
      staker: '',
      timestamp: 1679379071,
      type: 'NFT_LISTING'
   }
```
  