### PR TITLE
fix: specify fields on webhook update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 /node_modules
-/tests
 /dist
 .DS_Store

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "helius-sdk",
-  "version": "1.0.3",
+  "version": "1.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "helius-sdk",
-      "version": "1.0.3",
+      "version": "1.0.7",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.2.3"

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -19,6 +19,7 @@ export type HeliusOptions = {
 export interface Webhook {
   webhookID: string;
   wallet: string;
+  project: string;
   webhookURL: string;
   transactionTypes: string[];
   accountAddresses: string[];
@@ -34,8 +35,8 @@ export type CollectionIdentifier = {
   verifiedCollectionAddresses?: string[];
 };
 
-export type CreateWebhookRequest = Omit<Webhook, "webhookID" | "wallet">;
-export type EditWebhookRequest = Partial<Omit<Webhook, "webhookID" | "wallet">>;
+export type CreateWebhookRequest = Omit<Webhook, "webhookID" | "wallet" | "project">;
+export type EditWebhookRequest = Partial<Omit<Webhook, "webhookID" | "wallet" | "project">>;
 
 export interface CreateCollectionWebhookRequest extends CreateWebhookRequest {
   collectionQuery: CollectionIdentifier;

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -1,0 +1,14 @@
+
+import { Helius, WebhookType } from '../src/index';
+
+
+// Testing is ad-hoc for now.
+// This is an example to test your changes with your personal key. Modify as necessary.
+// Execute your test with `npx ts-node tests/test.ts`
+async function run() {
+    const helius = new Helius("your-api-key");
+    const webhook = "your-webhook-id";
+    await helius.editWebhook(webhook, { webhookType: WebhookType.ENHANCED })
+}
+
+run();


### PR DESCRIPTION
We need to explicitly specify the fields when we call "putWebhook" to avoid causing breaking changes when we add new fields to the webhook response.

Tested against my personal Helius account.