### PR TITLE
Update README.md to fix DAS docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ helius.createCollectionWebhook({
 Note that the Collections.ABC enum references the collection query for this collection. It is just a convenience enum so that developers don't have to figure out whether to use firstVerifiedCreator or the Metaplex Certified Collection address ([see more about this here](https://docs.helius.xyz/api-reference/nft-collections-on-solana)). If you already know it for your collection, please make a PR :)
 
 ## DAS API
-Read more about the DAS API from our docs, [here]("https://docs.helius.xyz/solana-compression/digital-asset-standard-das-api"). 
+Read more about the DAS API from our docs, [here](https://docs.helius.xyz/solana-compression/digital-asset-standard-das-api). 
 
 
 ### **getAsset**


### PR DESCRIPTION
Small fix to the README file. The DAS docs link was surrounded with inverted commas which breaks the link. 