### PR TITLE
Add sendTransactionWithPriorityFees Method

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,10 +111,7 @@ import { Helius, Address } from "helius-sdk";
 
 const helius = new Helius("<your-api-key-here>");
 
-helius.appendAddressesToWebhook("your-webhook-id-here", [
-  Address.SQUADS,
-  Address.JUPITER_V3,
-]);
+helius.appendAddressesToWebhook("your-webhook-id-here", [Address.SQUADS, Address.JUPITER_V3]);
 ```
 
 ### **Get All Webhooks**
@@ -196,10 +193,7 @@ Get multiple assets by ID (up to 1k).
 ```ts
 import { Helius } from "helius-sdk";
 
-const ids = [
-  "F9Lw3ki3hJ7PF9HQXsBzoY8GyE6sPoEZZdXJBsTTD2rk",
-  "F9Lw3ki3hJ7PF9HQXsBzoY8GyE6sPoEZZdXJBsTTD2rk",
-];
+const ids = ["F9Lw3ki3hJ7PF9HQXsBzoY8GyE6sPoEZZdXJBsTTD2rk", "F9Lw3ki3hJ7PF9HQXsBzoY8GyE6sPoEZZdXJBsTTD2rk"];
 const helius = new Helius("your-api-key");
 const response = await helius.rpc.getAssetBatch({
   ids: ids,
@@ -348,8 +342,7 @@ const response = await helius.mintCompressedNft({
       value: "Mythical",
     },
   ],
-  imageUrl:
-    "https://cdna.artstation.com/p/assets/images/images/052/118/830/large/julie-almoneda-03.jpg?1658992401",
+  imageUrl: "https://cdna.artstation.com/p/assets/images/images/052/118/830/large/julie-almoneda-03.jpg?1658992401",
   externalUrl: "https://www.yugioh-card.com/en/",
   sellerFeeBasisPoints: 6900,
 });
@@ -366,8 +359,7 @@ const response = await helius.mintCompressedNft({
   name: "Aggron",
   symbol: "AGNFT",
   owner: "OWNER_WALLET_ADDRESS",
-  description:
-    "Aggron is a powerful Steel/Rock-type Pokémon known for its iron defense.",
+  description: "Aggron is a powerful Steel/Rock-type Pokémon known for its iron defense.",
   attributes: [
     {
       trait_type: "Type",
@@ -472,10 +464,7 @@ import { Helius } from "helius-sdk";
 
 const helius = new Helius("<your-api-key-here>");
 
-const response = await helius.rpc.airdrop(
-  new PublicKey("<wallet address>"),
-  1000000000
-); // 1 sol
+const response = await helius.rpc.airdrop(new PublicKey("<wallet address>"), 1000000000); // 1 sol
 ```
 
 ### Get Solana Stake Accounts
@@ -496,4 +485,31 @@ import { Helius } from "helius-sdk";
 const helius = new Helius("<your-api-key-here>");
 
 const response = await helius.rpc.getTokenHolders("<token mint address>");
+```
+
+## Priority Fees
+
+We provide the `sendTransactionWithPriorityFees` to allow users to send a transaction with a specified priority fee. For example, if you wanted to transfer 5 SOL from one account to another using the SDK, it would look like the following:
+
+```ts
+import { Helius } from "helius-sdk";
+
+const helius = new Helius("<your-api-key-here>");
+
+// Create the transfer instruction
+const transferIx = SystemProgram.transfer({
+  fromPubkey: fromKeypair.publicKey,
+  toPubkey: toPubkey,
+  lamports: 5 * LAMPORTS_PER_SOL,
+});
+
+// Create a new transaction
+const transaction = new Transaction().add(transferIx);
+
+const response = await helius.rpc.sendTransactionWithPriorityFees(
+  transaction,
+  [fromKeypair],
+  3, // Compute Unit Price in micro-lamports
+  500_000 // Compute Unit Limit
+);
 ```

--- a/README.md
+++ b/README.md
@@ -492,7 +492,7 @@ const response = await helius.rpc.getTokenHolders("<token mint address>");
 We provide the `sendTransactionWithPriorityFees` to allow users to send a transaction with a specified priority fee. For example, if you wanted to transfer 5 SOL from one account to another using the SDK, it would look like the following:
 
 ```ts
-import { Helius } from "helius-sdk";
+import { Helius, PriorityFee } from "helius-sdk";
 
 const helius = new Helius("<your-api-key-here>");
 
@@ -506,9 +506,5 @@ const transferIx = SystemProgram.transfer({
 // Create a new transaction
 const transaction = new Transaction().add(transferIx);
 
-const response = await helius.rpc.sendTransactionWithPriorityFees(
-  transaction,
-  [fromKeypair],
-  3 // Compute Unit Price in micro-lamports
-);
+const response = await helius.rpc.sendTransactionWithPriorityFees(transaction, [fromKeypair], PriorityFee.High);
 ```

--- a/README.md
+++ b/README.md
@@ -509,7 +509,6 @@ const transaction = new Transaction().add(transferIx);
 const response = await helius.rpc.sendTransactionWithPriorityFees(
   transaction,
   [fromKeypair],
-  3, // Compute Unit Price in micro-lamports
-  500_000 // Compute Unit Limit
+  3 // Compute Unit Price in micro-lamports
 );
 ```

--- a/src/RpcClient.ts
+++ b/src/RpcClient.ts
@@ -18,6 +18,7 @@ import {
 } from "@solana/web3.js";
 import axios from "axios";
 import { DAS } from "./types/das-types";
+import { PriorityFee } from "./types";
 
 export type SendAndConfirmTransactionResponse = {
   signature: TransactionSignature;
@@ -348,7 +349,7 @@ export class RpcClient {
    *
    * @param {Transaction} transaction - the transaction to send
    * @param {Keypair[]} signers - the array of signers for the transaction
-   * @param {number} priorityFee - the priority fee in micro-lamports
+   * @param {PriorityFee} priorityLevel - the priority fee in micro-lamports
    * @param {ConfirmOptions} configOptions - additional configuration options (i.e., number of retries, preflight commitment, skip preflight)
    * @returns {Promise<string>} - a promise that resolves to the transaction ID
    * @throws {Error} - throws an error if the transaction is not sent successfully after the max number of retries
@@ -356,7 +357,7 @@ export class RpcClient {
   async sendTransactionWithPriorityFees(
     transaction: Transaction,
     signers: Keypair[],
-    priorityFee: number,
+    priorityLevel: PriorityFee,
     configOptions: ConfirmOptions
   ): Promise<string> {
     const defaultOptions: ConfirmOptions = {
@@ -365,6 +366,8 @@ export class RpcClient {
       preflightCommitment: "finalized",
       commitment: "finalized",
     };
+
+    const priorityFee = Number(PriorityFee[priorityLevel]);
 
     const options: ConfirmOptions = { ...defaultOptions, ...configOptions };
     const maxRetries = options.maxRetries!;

--- a/src/RpcClient.ts
+++ b/src/RpcClient.ts
@@ -349,7 +349,6 @@ export class RpcClient {
    * @param {Transaction} transaction - the transaction to send
    * @param {Keypair[]} signers - the array of signers for the transaction
    * @param {number} priorityFee - the priority fee in micro-lamports
-   * @param {number} computeLimit - the compute limit for the transaction
    * @param {ConfirmOptions} configOptions - additional configuration options (i.e., number of retries, preflight commitment, skip preflight)
    * @returns {Promise<string>} - a promise that resolves to the transaction ID
    * @throws {Error} - throws an error if the transaction is not sent successfully after the max number of retries
@@ -358,7 +357,6 @@ export class RpcClient {
     transaction: Transaction,
     signers: Keypair[],
     priorityFee: number,
-    computeLimit: number = 200_000,
     configOptions: ConfirmOptions
   ): Promise<string> {
     const defaultOptions: ConfirmOptions = {
@@ -372,10 +370,9 @@ export class RpcClient {
     const maxRetries = options.maxRetries!;
 
     const computePriceIx = ComputeBudgetProgram.setComputeUnitPrice({ microLamports: priorityFee });
-    const computeLimitIx = ComputeBudgetProgram.setComputeUnitLimit({ units: computeLimit });
 
     const newTransaction = new Transaction();
-    newTransaction.add(computePriceIx, computeLimitIx);
+    newTransaction.add(computePriceIx);
     newTransaction.add(...transaction.instructions);
     newTransaction.feePayer = transaction.feePayer || signers[0].publicKey;
 

--- a/src/types/enums.ts
+++ b/src/types/enums.ts
@@ -193,9 +193,7 @@ export const Collections = {
     firstVerifiedCreators: ["GVkb5GuwGKydA4xXLT9PNpx63h7bhFNrDLQSxi6j5NuF"],
   },
   DEGODS: {
-    verifiedCollectionAddresses: [
-      "6XxjKYFbcndh2gDcsUrmZgVEsoDxXMnfsaGY6fpTJzNr",
-    ],
+    verifiedCollectionAddresses: ["6XxjKYFbcndh2gDcsUrmZgVEsoDxXMnfsaGY6fpTJzNr"],
   },
 };
 
@@ -568,4 +566,11 @@ export enum Group {
 export enum MintApiAuthority {
   MAINNET = "HnT5KVAywGgQDhmh6Usk4bxRg4RwKxCK4jmECyaDth5R",
   DEVNET = "2LbAtCJSaHqTnP9M5QSjvAMXk79RNLusFspFN5Ew67TC",
+}
+
+export enum PriorityFee {
+  None = 0,
+  Normal = 5,
+  High = 25,
+  Turbo = 50,
 }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -246,9 +246,3 @@ export interface RevokeCollectionAuthorityRequest {
   revokeAuthorityKeypair: Keypair;
   payerKeypair?: Keypair;
 }
-
-export type configOptions = {
-  maxRetries?: number;
-  preflightCommitment?: "processed" | "confirmed" | "finalized";
-  skipPreflight?: boolean;
-};

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,4 +1,4 @@
-import type { Cluster, Keypair, TransactionError } from '@solana/web3.js'
+import type { Cluster, Keypair, TransactionError } from "@solana/web3.js";
 
 import type {
   WebhookType,
@@ -11,7 +11,7 @@ import type {
   AccountWebhookEncoding,
 } from "./enums";
 
-export type HeliusCluster = Omit<Cluster, 'testnet'>
+export type HeliusCluster = Omit<Cluster, "testnet">;
 
 export interface HeliusEndpoints {
   api: string;
@@ -42,13 +42,8 @@ export type CollectionIdentifier = {
   verifiedCollectionAddresses?: string[];
 };
 
-export type CreateWebhookRequest = Omit<
-  Webhook,
-  "webhookID" | "wallet" | "project"
->;
-export type EditWebhookRequest = Partial<
-  Omit<Webhook, "webhookID" | "wallet" | "project">
->;
+export type CreateWebhookRequest = Omit<Webhook, "webhookID" | "wallet" | "project">;
+export type EditWebhookRequest = Partial<Omit<Webhook, "webhookID" | "wallet" | "project">>;
 
 export interface CreateCollectionWebhookRequest extends CreateWebhookRequest {
   collectionQuery: CollectionIdentifier;
@@ -251,3 +246,9 @@ export interface RevokeCollectionAuthorityRequest {
   revokeAuthorityKeypair: Keypair;
   payerKeypair?: Keypair;
 }
+
+export type configOptions = {
+  maxRetries?: number;
+  preflightCommitment?: "processed" | "confirmed" | "finalized";
+  skipPreflight?: boolean;
+};


### PR DESCRIPTION
This PR aims to add the `sendTransactionWithPriorityFees` method to the RPC Client. This will allow users to send a transaction with a specified priority fee (i.e., `ComputeUnitPrice`) and an optional compute unit limit