### PR TITLE
Add tokenType Param to SearchAssetsRequest

### DIFF
--- a/src/types/das-types.ts
+++ b/src/types/das-types.ts
@@ -77,7 +77,7 @@ export interface SearchAssetsRequest {
   royaltyTargetType?: RoyaltyModel;
   compressible?: boolean;
   compressed?: boolean;
-  tokenType?: string;
+  tokenType?: "fungible" | "nonFungible" | "regularNFT" | "compressedNFT" | "all" | (string & {});
 }
 
 // getAssetsByAuthority

--- a/src/types/das-types.ts
+++ b/src/types/das-types.ts
@@ -77,6 +77,7 @@ export interface SearchAssetsRequest {
   royaltyTargetType?: RoyaltyModel;
   compressible?: boolean;
   compressed?: boolean;
+  tokenType?: string;
 }
 
 // getAssetsByAuthority


### PR DESCRIPTION
This PR aims to add the `tokenType` parameter to `SearchAssetsRequest`. We allow users to filter by a token type via the Fungible Token Extension for search asset calls, however, this isn't currently possible with the SDK