### PR TITLE
Compressed nft event should be an array

### DIFF
--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -185,7 +185,7 @@ export interface NFTEvent {
 export interface TransactionEvent {
   nft: NFTEvent | null;
   swap: SwapEvent | null;
-  compressed: CompressedNftEvent | null;
+  compressed: CompressedNftEvent[] | null;
 }
 
 export interface EnrichedTransaction {


### PR DESCRIPTION
Compressed nft event is an array

See https://xray.helius.xyz/tx/5VCfxHnEmDMtzgr8qJJeUg3nSSQvhdh27qSEoWZsWBCC9KrEPaS3gZrM6Ar42JyT9hTMSpbW89d9XvBmjN4PMmvt?network=devnet

closes #68 
