### PR TITLE
[Fix] Change `delegate` type to `string`

### DIFF
--- a/src/types/das-types.ts
+++ b/src/types/das-types.ts
@@ -71,7 +71,7 @@ export namespace DAS {
     supplyMint?: string;
     supply?: number;
     interface?: string;
-    delegate?: number;
+    delegate?: string;
     ownerType?: OwnershipModel;
     royaltyAmount?: number;
     royaltyTarget?: string;


### PR DESCRIPTION
This PR addresses #63 by changing the `SearchAssetsRequest`'s `delegate` type to `string` since it expects an address