### PR TITLE
[Feat] Add `getPriorityFeeEstimate` Method

### DIFF
--- a/src/RpcClient.ts
+++ b/src/RpcClient.ts
@@ -449,4 +449,29 @@ export class RpcClient {
       throw new Error(`Error in getNftEditions: ${error}`);
     }
   }
+
+  /**
+   * Get information about all token accounts for a specific mint or a specific owner
+   * @returns {Promise<DAS.GetTokenAccountsResponse>}
+   * @throws {Error}
+   */
+  async getTokenAccounts(
+    params: DAS.GetTokenAccountsRequest
+  ): Promise<DAS.GetTokenAccountsResponse> {
+    try {
+      const url = `${this.connection.rpcEndpoint}`;
+      const response = await axios.post(url, {
+        jsonrpc: "2.0",
+        id: this.id,
+        method: "getTokenAccounts",
+        params: params,
+      }, {
+        headers: { "Content-Type": "application/json" },
+      });
+
+      return response.data.result as DAS.GetTokenAccountsResponse;
+    } catch (error) {
+      throw new Error(`Error in getTokenAccounts: ${error}`)
+    }
+  }
 }

--- a/src/RpcClient.ts
+++ b/src/RpcClient.ts
@@ -13,6 +13,7 @@ import {
 } from "@solana/web3.js";
 import axios from "axios";
 import { DAS } from "./types/das-types";
+import { GetPriorityFeeEstimateRequest, GetPriorityFeeEstimateResponse } from "./types";
 
 export type SendAndConfirmTransactionResponse = {
   signature: TransactionSignature;
@@ -396,6 +397,31 @@ export class RpcClient {
       return data.result as DAS.GetSignaturesForAssetResponse;
     } catch (error) {
       throw new Error(`Error in getSignaturesForAsset: ${error}`);
+    }
+  }
+
+  /**
+  * Get priority fee estimate
+  * @returns {Promise<GetPriorityFeeEstimateResponse>}
+  * @throws {Error}
+  */
+  async getPriorityFeeEstimate(
+    params: GetPriorityFeeEstimateRequest
+  ): Promise<GetPriorityFeeEstimateResponse> {
+    try {
+      const url = `${this.connection.rpcEndpoint}`;
+      const response = await axios.post(url, {
+        jsonrpc: "2.0",
+        id: this.id,
+        method: "getPriorityFeeEstimate",
+        params: [params],
+      }, {
+        headers: { "Content-Type": "application/json" },
+      });
+
+      return response.data.result as GetPriorityFeeEstimateResponse;
+    } catch (error) {
+      throw new Error(`Error fetching priority fee estimate: ${error}`);
     }
   }
 }

--- a/src/types/enums.ts
+++ b/src/types/enums.ts
@@ -570,3 +570,21 @@ export enum MintApiAuthority {
   MAINNET = "HnT5KVAywGgQDhmh6Usk4bxRg4RwKxCK4jmECyaDth5R",
   DEVNET = "2LbAtCJSaHqTnP9M5QSjvAMXk79RNLusFspFN5Ew67TC",
 }
+
+export enum PriorityLevel {
+  NONE = "NONE",
+  LOW = "LOW",
+  MEDIUM = "MEDIUM",
+  HIGH = "HIGH",
+  VERY_HIGH = "VERY_HIGH",
+  UNSAFE_MAX = "UNSAFE_MAX",
+  DEFAULT = "DEFAULT",
+}
+
+export enum UiTransactionEncoding {
+  Binary = "Binary",
+  Base64 = "Base64",
+  Base58 = "Base58",
+  Json = "Json",
+  JsonParsed = "JsonParsed",
+}

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -329,7 +329,7 @@ export interface GetPriorityFeeEstimateOptions {
 
 export interface GetPriorityFeeEstimateRequest {
   transaction?: string;
-  accountKeys?: string [];
+  accountKeys?: string[];
   options?: GetPriorityFeeEstimateOptions;
 }
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -9,6 +9,8 @@ import type {
   TransactionContext,
   TxnStatus,
   AccountWebhookEncoding,
+  PriorityLevel,
+  UiTransactionEncoding,
 } from "./enums";
 
 export type HeliusCluster = Omit<Cluster, "testnet">;
@@ -316,4 +318,31 @@ export interface FullRwaAccount {
   data_registry?: DataRegistryAccount;
   identity_registry?: IdentityRegistryAccount;
   policy_engine?: PolicyEngine;
+}
+
+export interface GetPriorityFeeEstimateOptions {
+  priorityLevel?: PriorityLevel;
+  includeAllPriorityFeeLevels?: boolean;
+  transactionEncoding?: UiTransactionEncoding;
+  lookbackSlots?: number;
+}
+
+export interface GetPriorityFeeEstimateRequest {
+  transaction?: string;
+  accountKeys?: string [];
+  options?: GetPriorityFeeEstimateOptions;
+}
+
+export interface MicroLamportPriorityFeeLevels {
+  none: number;
+  low: number;
+  medium: number;
+  high: number;
+  veryHigh: number;
+  unsafeMax: number;
+}
+
+export interface GetPriorityFeeEstimateResponse {
+  priorityFeeEstimate?: number;
+  priorityFeeLevels?: MicroLamportPriorityFeeLevels; 
 }


### PR DESCRIPTION
This PR aims to add the [`getPriorityFeeEstimate` method](https://docs.helius.dev/solana-rpc-nodes/alpha-priority-fee-api#helius-priority-fee-api-an-improved-solution) to the SDK