### PR TITLE
[Fix] Add `TransactionType` Enum to `Webhook` Interface

### DIFF
--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -28,7 +28,7 @@ export interface Webhook {
   wallet: string;
   project: string;
   webhookURL: string;
-  transactionTypes: string[];
+  transactionTypes: TransactionType[];
   accountAddresses: string[];
   accountAddressOwners?: string[];
   webhookType?: WebhookType;


### PR DESCRIPTION
This PR seeks to address #15 by adding the `TransactionType` enum to the `Webhook` interface for better type support