### PR TITLE
[Fix] Update `grand_total` Type

### DIFF
--- a/src/types/das-types.ts
+++ b/src/types/das-types.ts
@@ -145,7 +145,7 @@ export interface SearchAssetsRequest {
     items: FullRwaAccount
   };
   export type GetAssetResponseList = {
-    grand_total?: boolean;
+    grand_total?: number | undefined;
     total: number;
     limit: number;
     page: number;

--- a/src/types/das-types.ts
+++ b/src/types/das-types.ts
@@ -145,7 +145,7 @@ export interface SearchAssetsRequest {
     items: FullRwaAccount
   };
   export type GetAssetResponseList = {
-    grand_total?: number | undefined;
+    grand_total?: number;
     total: number;
     limit: number;
     page: number;


### PR DESCRIPTION
This PR directly addresses #64 by updating `GetAssetResponseList`'s `grand_total` field to a `number` or `undefined`