### PR TITLE
fix(txts): Better Error Logging For `getComputeUnits`

### DIFF
--- a/src/RpcClient.ts
+++ b/src/RpcClient.ts
@@ -466,7 +466,7 @@ export class RpcClient {
     });
 
     if (rpcResponse.value.err) {
-      console.error(`Simulation error: ${rpcResponse.value.err}`);
+      console.error(`Simulation error: ${JSON.stringify(rpcResponse.value.err, null, 2)}`);
       return null;
     }
 


### PR DESCRIPTION
This PR aims to address the issue outlined in #95 by stringifying the error object