### PR TITLE
feat(txts): Implement Jito Smart Transactions

### DIFF
--- a/src/RpcClient.ts
+++ b/src/RpcClient.ts
@@ -18,12 +18,13 @@ import {
   ComputeBudgetProgram,
   SendOptions,
   Signer,
-  TransactionExpiredTimeoutError,
+  SystemProgram,
 } from "@solana/web3.js";
 const bs58 = require("bs58");
 import axios from "axios";
+
 import { DAS } from "./types/das-types";
-import { GetPriorityFeeEstimateRequest, GetPriorityFeeEstimateResponse, PriorityLevel } from "./types";
+import { GetPriorityFeeEstimateRequest, GetPriorityFeeEstimateResponse, JITO_TIP_ACCOUNTS } from "./types";
 
 export type SendAndConfirmTransactionResponse = {
   signature: TransactionSignature;
@@ -665,6 +666,28 @@ export class RpcClient {
     }
   
     throw new Error("Transaction failed to confirm in 60s");
+  }
+
+  /**
+   * Add a tip instruction to the last instruction in the bundle
+   * @param {TransactionInstruction[]} instructions - The transaction instructions
+   * @param {PublicKey} feePayer - The public key of the fee payer
+   * @param {string} tipAccount - The public key of the tip account
+   * @param {number} tipAmount - The amount of lamports to tip
+   */
+   addTipInstruction(
+    instructions: TransactionInstruction[],
+    feePayer: PublicKey,
+    tipAccount: string,
+    tipAmount: number,
+  ): void {
+    const tipInstruction = SystemProgram.transfer({
+      fromPubkey: feePayer,
+      toPubkey: new PublicKey(tipAccount),
+      lamports: tipAmount,
+    });
+
+    instructions.push(tipInstruction);
   }
  
   /**

--- a/src/RpcClient.ts
+++ b/src/RpcClient.ts
@@ -752,6 +752,32 @@ export class RpcClient {
   }
 
   /**
+   * Get the status of Jito bundles
+   * @param {string[]} bundleIds - An array of bundle IDs to check the status for
+   * @param {string} jitoApiUrl - The Jito Block Engine API URL
+   * @returns {Promise<any>} - The status of the bundles 
+   */
+  async getBundleStatuses(
+    bundleIds: string[],
+    jitoApiUrl: string,
+  ): Promise<any> {
+    const response = await axios.post(jitoApiUrl, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "getBundleStatuses",
+      params: [bundleIds],
+    }, {
+      headers: { "Content-Type": "application/json" },
+    });
+
+    if (response.data.error) {
+      throw new Error(`Error getting bundle statuses: ${JSON.stringify(response.data.error, null, 2)}`);
+    }
+
+    return response.data.result;
+  }
+
+  /**
    * Send a smart transaction as a Jito bundle with a tip
    * @param {TransactionInstruction[]} instructions - The transaction instructions
    * @param {Signer[]} signers - The transaction's signers. The first signer should be the fee payer if a separate one isn't provided

--- a/src/RpcClient.ts
+++ b/src/RpcClient.ts
@@ -818,10 +818,10 @@ export class RpcClient {
       const bundleStatuses = await this.getBundleStatuses([bundleId], jitoApiUrl);
 
       if (bundleStatuses && bundleStatuses.value && bundleStatuses.value.length > 0) {
-        const status = bundleStatuses.value[0].confirmationStatus;
+        const status = bundleStatuses.value[0].confirmation_status;
 
         if (status === "confirmed") {
-          return bundleId;
+          return bundleStatuses.value[0].transactions[0];
         }
       }
 

--- a/src/RpcClient.ts
+++ b/src/RpcClient.ts
@@ -724,6 +724,32 @@ export class RpcClient {
     // Return the serialized transaction
     return bs58.encode(smartTransaction.serialize());
   }
+
+  /**
+   * Send a bundle of transactions to the Jito Block Engine
+   * @param {string[]} serializedTransactions - The serialized transactions in the bundle
+   * @param {string} jitoApiUrl - The Jito Block Engine API URL
+   * @returns {Promise<string>} - The bundle ID
+   */
+  async sendJitoBundle(
+    serializedTransactions: string[],
+    jitoApiUrl: string,
+  ): Promise<string> {
+    const response = await axios.post(jitoApiUrl, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "sendBundle",
+      params: [serializedTransactions],
+    }, {
+      headers: { "Content-Type": "application/json" },
+    });
+
+    if (response.data.error) {
+      throw new Error(`Error sending bundles: ${JSON.stringify(response.data.error, null, 2)}`);
+    }
+
+    return response.data.result;
+  }
  
   /**
    * Get information about all the edition NFTs for a specific master NFT

--- a/src/types/enums.ts
+++ b/src/types/enums.ts
@@ -1,3 +1,5 @@
+import { JitoRegion } from "./types";
+
 export enum WebhookType {
   ENHANCED = "enhanced",
   RAW = "raw",
@@ -588,3 +590,22 @@ export enum UiTransactionEncoding {
   Json = "Json",
   JsonParsed = "JsonParsed",
 }
+
+export const JITO_TIP_ACCOUNTS: string[] = [
+  "96gYZGLnJYVFmbjzopPSU6QiEV5fGqZNyN9nmNhvrZU5",
+  "HFqU5x63VTqvQss8hp11i4wVV8bD44PvwucfZ2bU7gRe",
+  "Cw8CFyM9FkoMi7K7Crf6HNQqf4uEMzpKw6QNghXLvLkY",
+  "ADaUMid9yfUytqMBgopwjb2DTLSokTSzL1zt6iGPaS49",
+  "DfXygSm4jCyNCybVYYK6DwvWqjKee8pbDmJGcLWNDXjh",
+  "ADuUkR4vqLUMWXxW9gh6D6L8pMSawimctcNZ5pGwDcEt",
+  "DttWaMuVvTiduZRnguLF7jNxTgiMBZ1hyAumKUiL2KRL",
+  "3AVi9Tg9Uo68tJfuvoKvqKNWKkC5wPdSSdeBnizKZ6jT",
+];
+
+export const JITO_API_URLS: Record<JitoRegion, string> = {
+  Default: "https://mainnet.block-engine.jito.wtf",
+  NY: "https://ny.mainnet.block-engine.jito.wtf",
+  Amsterdam: "https://amsterdam.mainnet.block-engine.jito.wtf",
+  Frankfurt: "https://frankfurt.mainnet.block-engine.jito.wtf",
+  Tokyo: "https://tokyo.mainnet.block-engine.jito.wtf",
+};

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -347,3 +347,5 @@ export interface GetPriorityFeeEstimateResponse {
   priorityFeeEstimate?: number;
   priorityFeeLevels?: MicroLamportPriorityFeeLevels; 
 }
+
+export type JitoRegion = "Default" | "NY" | "Amsterdam" | "Frankfurt" | "Tokyo";


### PR DESCRIPTION
This PR aims to implement the first version of Jito Smart Transactions, as well as add a whole host of Jito functionality to the SDK. For the first iteration, we allow users to create a single, optimized transaction that pays a Jito tip with the method `createSmartTransactionWithTip`. We also provide creating, sending, and polling functionality for a single, optimized transaction with a Jito tip with the method `sendSmartTransactionWithTip`

Note this PR should be merged after #100 