### PR TITLE
fix(txts): `sendSmartTransaction` Times Out But Transaction Is Confirmed

### DIFF
--- a/src/RpcClient.ts
+++ b/src/RpcClient.ts
@@ -658,9 +658,12 @@ export class RpcClient {
       // Create a smart transaction
       const { smartTransaction: transaction, lastValidBlockHeight } = await this.createSmartTransaction(instructions, signers, lookupTables, sendOptions.feePayer);
 
+      // Timeout of 60s. The transaction will be routed through our staked connections and should be confirmed by then
+      const timeout = 60000;
+      const startTime = Date.now();
       let txtSig;
   
-      while ((await this.connection.getBlockHeight()) <= lastValidBlockHeight) {
+      while (Date.now() - startTime < timeout || (await this.connection.getBlockHeight()) <= lastValidBlockHeight) {
         try {
           txtSig = await this.connection.sendRawTransaction(transaction.serialize(), {
             skipPreflight: sendOptions.skipPreflight,

--- a/src/RpcClient.ts
+++ b/src/RpcClient.ts
@@ -511,14 +511,14 @@ export class RpcClient {
    * @param {Signer[]} signers - The transaction's signers. The first signer should be the fee payer
    * @param {AddressLookupTableAccount[]} lookupTables - The lookup tables to be included in a versioned transaction. Defaults to `[]`
    * @param {Signer} feePayer - Optional fee payer separate from the signers
-   * @returns {Promise<TransactionSignature>} - The transaction signature
+   * @returns {Promise<{ smartTransaction: Transaction | VersionedTransaction, lastValidBlockHeight: number }>} - The transaction and the last valid block height
   */
   async createSmartTransaction(
     instructions: TransactionInstruction[],
     signers: Signer[],
     lookupTables: AddressLookupTableAccount[] = [],
     feePayer?: Signer,
-  ) {
+  ): Promise<{ smartTransaction: Transaction | VersionedTransaction, lastValidBlockHeight: number }> {
     if (!signers.length) {
       throw new Error("The transaction must have at least one signer");
     }


### PR DESCRIPTION
Fixes #102 by throwing timeout error only if the current block height is greater than the `lastValidBlockHeight` returned by `getLatestBlockhash` used when creating the transaction. 