### PR TITLE
fix(prettier): Better Formatting

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,6 @@
         "node": true
     },
     "extends": [
-        "airbnb-base",
         "prettier"
     ],
     "globals": {
@@ -20,7 +19,5 @@
         "@typescript-eslint",
         "prettier"
     ],
-    "rules": {
-        "prettier/prettier": "error"
-    }
+    "rules": {}
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,12 +1,12 @@
 {
-    "printWidth": 80,
-    "tabWidth": 2,
-    "useTabs": false,
-    "semi": true,
-    "singleQuote": true,
-    "trailingComma": "es5",
-    "bracketSpacing": true,
-    "arrowParens": "always",
-    "endOfLine": "lf"
-  }
+  "printWidth": 80,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "bracketSpacing": true,
+  "arrowParens": "always",
+  "endOfLine": "lf"
+}
   

--- a/src/types/enums.ts
+++ b/src/types/enums.ts
@@ -505,17 +505,17 @@ export enum TokenStandard {
 }
 
 export enum Interface {
-  V1NFT = "V1_NFT",
-  CUSTOM = "Custom",
-  V1PRINT = "V1_PRINT",
-  LEGACYNFT = "Legacy_NFT",
-  V2NFT = "V2_NFT",
-  FUNGIBLE_ASSET = "FungibleAsset",
-  IDENTITY = "Identity",
-  EXECUTABLE = "Executable",
-  PROGRAMMABLENFT = "ProgrammableNFT",
-  FUNGIBLE_TOKEN = "FungibleToken",
-  MPL_CORE_ASSET = "MplCoreAsset",
+  V1NFT = 'V1_NFT',
+  CUSTOM = 'Custom',
+  V1PRINT = 'V1_PRINT',
+  LEGACYNFT = 'Legacy_NFT',
+  V2NFT = 'V2_NFT',
+  FUNGIBLE_ASSET = 'FungibleAsset',
+  IDENTITY = 'Identity',
+  EXECUTABLE = 'Executable',
+  PROGRAMMABLENFT = 'ProgrammableNFT',
+  FUNGIBLE_TOKEN = 'FungibleToken',
+  MPL_CORE_ASSET = 'MplCoreAsset',
 }
 
 export enum OwnershipModel {


### PR DESCRIPTION
This PR aims to temporarily disable the strict ESLint errors causing build issues and fix the formatting for the `.prettierrc` and `src/types/enums.ts` files