### PR TITLE
feat(txts): Add `serializeOptions` For Legacy Transactions

### DIFF
--- a/src/RpcClient.ts
+++ b/src/RpcClient.ts
@@ -600,7 +600,7 @@ export class RpcClient {
     }
 
     // Serialize the transaction
-    let serializedTransaction = bs58.encode(
+    const serializedTransaction = bs58.encode(
       isVersioned
         ? versionedTransaction!.serialize()
         : legacyTransaction!.serialize(serializeOptions)

--- a/src/RpcClient.ts
+++ b/src/RpcClient.ts
@@ -533,7 +533,7 @@ export class RpcClient {
    * @param {Signer[]} signers - The transaction's signers. The first signer should be the fee payer
    * @param {AddressLookupTableAccount[]} lookupTables - The lookup tables to be included in a versioned transaction. Defaults to `[]`
    * @param {Signer} feePayer - Optional fee payer separate from the signers
-   * @param {SerializeConfig} serializeOptions - Options for transaction serialization. This applies only to legacy transactions. Defaults to `{ requireALlSignatures = true, verifySignatures: true }`
+   * @param {SerializeConfig} serializeOptions - Options for transaction serialization. This applies only to legacy transactions. Defaults to `{ requireAllSignatures = true, verifySignatures: true }`
    * @returns {Promise<SmartTransactionContext>} - The transaction with blockhash, blockheight and slot
    */
   async createSmartTransaction(

--- a/src/RpcClient.ts
+++ b/src/RpcClient.ts
@@ -538,7 +538,10 @@ export class RpcClient {
     signers: Signer[],
     lookupTables: AddressLookupTableAccount[] = [],
     feePayer?: Signer,
-    serializeOptions: SerializeConfig = { requireAllSignatures: true, verifySignatures: true },
+    serializeOptions: SerializeConfig = {
+      requireAllSignatures: true,
+      verifySignatures: true,
+    }
   ): Promise<{
     smartTransaction: Transaction | VersionedTransaction;
     lastValidBlockHeight: number;
@@ -597,15 +600,11 @@ export class RpcClient {
     }
 
     // Serialize the transaction
-    let serializedTransaction: string;
-
-    if (isVersioned) {
-      // For versioned transactions, serialize() doesn't accept options
-      serializedTransaction = bs58.encode(versionedTransaction!.serialize());
-    } else {
-      // For legacy transactions, we can use the requireAllSignatures option
-      serializedTransaction = bs58.encode(legacyTransaction!.serialize(serializeOptions));
-    }
+    let serializedTransaction = bs58.encode(
+      isVersioned
+        ? versionedTransaction!.serialize()
+        : legacyTransaction!.serialize(serializeOptions)
+    );
 
     // Get the priority fee estimate based on the serialized transaction
     const priorityFeeEstimateResponse = await this.getPriorityFeeEstimate({


### PR DESCRIPTION
This PR aims to modify the serialization process in `createSmartTransactions`. This is done so users can specify whether they would like to require all signatures or signature verification, giving them greater control over the smart transaction creation process