### PR TITLE
Fix pollTransactionConfirmation not recognizing finalized transactions

### DIFF
--- a/src/RpcClient.ts
+++ b/src/RpcClient.ts
@@ -515,7 +515,7 @@ export class RpcClient {
 
         const status = await this.connection.getSignatureStatus(txtSig);
 
-        if (status?.value?.confirmationStatus === 'confirmed') {
+        if (status?.value?.confirmationStatus === 'confirmed' || status?.value?.confirmationStatus === 'finalized') {
           clearInterval(intervalId);
           resolve(txtSig);
         }


### PR DESCRIPTION
Between the 5 seconds retry interval a transaction can enter into the finalized phase without getting checked while it was confirmed. This could result as a transaction not getting recognized as confirmed yet it is.