### PR TITLE
fix(types): Update `DisplayOptions` and `GetAssetDisplayOptions`

### DIFF
--- a/src/types/das-types.ts
+++ b/src/types/das-types.ts
@@ -173,12 +173,24 @@ export namespace DAS {
     showUnverifiedCollections?: boolean;
     showCollectionMetadata?: boolean;
     showGrandTotal?: boolean;
+    showRawData?: boolean;
+    showFungible?: boolean;
+    requireFullIndex?: boolean;
+    showSystemMetadata?: boolean;
+    showZeroBalance?: boolean;
+    showClosedAccounts?: boolean;
   };
 
   // Display options for getAssetBatch do not include grand_total.
   export type GetAssetDisplayOptions = {
     showUnverifiedCollections?: boolean;
     showCollectionMetadata?: boolean;
+    showRawData?: boolean;
+    showFungible?: boolean;
+    requireFullIndex?: boolean;
+    showSystemMetadata?: boolean;
+    showNativeBalance?: boolean;
+    showInscription?: boolean;
   };
 
   // Ownership --


### PR DESCRIPTION
This PR aims to add the necessary display options to `DisplayOptions` and `GetAssetDisplayOptions` to close #62. The types added are in line with [the Rust SDK's current types](https://github.com/helius-labs/helius-rust-sdk/blob/cbd01242807cd4aaff3dc27d21d98163a7999e8a/src/types/options.rs#L3-L28)