### PR TITLE
fix(types): Add `token_extensions` for `TokenAccount`

### DIFF
--- a/src/RpcClient.ts
+++ b/src/RpcClient.ts
@@ -19,7 +19,6 @@ import {
   SendOptions,
   Signer,
   SystemProgram,
-  TransactionConfirmationStatus,
   TransactionExpiredBlockheightExceededError,
 } from '@solana/web3.js';
 import bs58 from 'bs58';
@@ -27,7 +26,6 @@ import axios from 'axios';
 
 import { DAS } from './types/das-types';
 import {
-  Address,
   GetPriorityFeeEstimateRequest,
   GetPriorityFeeEstimateResponse,
   JITO_API_URLS,

--- a/src/types/das-types.ts
+++ b/src/types/das-types.ts
@@ -324,6 +324,7 @@ export namespace DAS {
     amount?: number;
     delegated_amount?: number;
     frozen?: boolean;
+    // TODO: Add proper typing for token extensions instead of using `any`
     token_extensions: any;
   }
 

--- a/src/types/das-types.ts
+++ b/src/types/das-types.ts
@@ -324,6 +324,7 @@ export namespace DAS {
     amount?: number;
     delegated_amount?: number;
     frozen?: boolean;
+    token_extensions: any;
   }
 
   export interface GetTokenAccountsRequest {


### PR DESCRIPTION
This PR aims to add the `token_extensions` field to `TokenAccount` to resolve #121. This PR also removes the unused imports in `RpcClient.ts` 