### PR TITLE
fix(txts): Better `getComputeUnits`

### DIFF
--- a/README.md
+++ b/README.md
@@ -717,10 +717,10 @@ const { smartTransaction: transaction, lastValidBlockHeight } = await helius.rpc
 ```
 
 ### getComputeUnits()
-This method simulates a transaction to get the total compute units consumed. It takes in an array of instructions, a fee payer, and an array of lookup tables. It returns the compute units consumed, or null if unsuccessful:
+This method simulates a transaction to get the total compute units consumed. It takes in an array of instructions, a fee payer, an array of lookup tables, and an array of signers. It returns the compute units consumed, or null if unsuccessful:
 
 ```ts
-const units = helius.rpc.getComputeUnits(instructions, payerKey, []);
+const units = helius.rpc.getComputeUnits(instructions, payerKey, [], []);
 ```
 
 ### pollTransactionConfirmation()

--- a/src/RpcClient.ts
+++ b/src/RpcClient.ts
@@ -485,7 +485,6 @@ export class RpcClient {
     const rpcResponse = await this.connection.simulateTransaction(
       testTransaction,
       {
-        replaceRecentBlockhash: true,
         sigVerify: !!signers,
       }
     );

--- a/src/RpcClient.ts
+++ b/src/RpcClient.ts
@@ -456,12 +456,14 @@ export class RpcClient {
    * @param {TransactionInstruction[]} instructions - The transaction instructions
    * @param {PublicKey} payer - The public key of the payer
    * @param {AddressLookupTableAccount[]} lookupTables - The address lookup tables
+   * @param {Signer[]} signers - Optional signers for the transaction
    * @returns {Promise<number | null>} - The compute units consumed, or null if unsuccessful
    */
   async getComputeUnits(
     instructions: TransactionInstruction[],
     payer: PublicKey,
-    lookupTables: AddressLookupTableAccount[]
+    lookupTables: AddressLookupTableAccount[],
+    signers?: Signer[]
   ): Promise<number | null> {
     const testInstructions = [
       ComputeBudgetProgram.setComputeUnitLimit({ units: 1_400_000 }),
@@ -476,11 +478,15 @@ export class RpcClient {
       }).compileToV0Message(lookupTables)
     );
 
+    if (signers) {
+      testTransaction.sign(signers);
+    }
+
     const rpcResponse = await this.connection.simulateTransaction(
       testTransaction,
       {
         replaceRecentBlockhash: true,
-        sigVerify: false,
+        sigVerify: !!signers,
       }
     );
 
@@ -629,7 +635,8 @@ export class RpcClient {
     const units = await this.getComputeUnits(
       instructions,
       payerKey,
-      isVersioned ? lookupTables : []
+      isVersioned ? lookupTables : [],
+      signers
     );
 
     if (!units) {


### PR DESCRIPTION
This PR aims to align with the [Rust SDK's recent PR](https://github.com/helius-labs/helius-rust-sdk/pull/60), which allows the user to skip signature verification for `getComputeUnits` if no signers are provided