### PR TITLE
Update `sendSmartTransaction`'s `lastValidBlockHeightOffset` type definition

### DIFF
--- a/src/RpcClient.ts
+++ b/src/RpcClient.ts
@@ -712,7 +712,7 @@ export class RpcClient {
     lookupTables: AddressLookupTableAccount[] = [],
     sendOptions: SendOptions & {
       feePayer?: Signer;
-      lastValidBlockHeightOffset: number;
+      lastValidBlockHeightOffset?: number;
     } = { skipPreflight: false, lastValidBlockHeightOffset: 150 }
   ): Promise<TransactionSignature> {
     if (sendOptions.lastValidBlockHeightOffset < 0)


### PR DESCRIPTION
`lastValidBlockHeightOffset` is meant to default to `150`, and should not be required by the consumer to specify. So I'm simply updating the type here to be an optional parameter because if we don't the change would be seemingly non-backwards-compatible (users **can** just specify `lastValidBlockHeightOffset` of `150` on v1.3.5 though) and might require a major version change otherwise since this could be considered a "breaking" change, if typescript fails to pass the type-checker

This resolves https://github.com/helius-labs/helius-sdk/issues/131 