### PR TITLE
Update tx encoding casing

### DIFF
--- a/src/types/enums.ts
+++ b/src/types/enums.ts
@@ -585,11 +585,11 @@ export enum PriorityLevel {
 }
 
 export enum UiTransactionEncoding {
-  Binary = 'Binary',
-  Base64 = 'Base64',
-  Base58 = 'Base58',
-  Json = 'Json',
-  JsonParsed = 'JsonParsed',
+  Binary = 'binary',
+  Base64 = 'base64',
+  Base58 = 'base58',
+  Json = 'json',
+  JsonParsed = 'jsonParsed',
 }
 
 // https://jito-foundation.gitbook.io/mev/mev-payment-and-distribution/on-chain-addresses


### PR DESCRIPTION
Priority Fee API expected encoding in lowercase but the enum values are in uppercase so the payload was always incorrect