### PR TITLE
fix(types): Add `total_price` to `PriceInfo`

### DIFF
--- a/src/types/das-types.ts
+++ b/src/types/das-types.ts
@@ -488,6 +488,7 @@ export namespace DAS {
   export interface PriceInfo {
     price_per_token: number;
     currency: string;
+    total_price?: number;
   }
   // End of DAS
 }


### PR DESCRIPTION
This PR aims to add the `total_price` field to the `PriceInfo` interface, which resolves #130 