### PR TITLE
fix(types): Add `showNativeBalance` to `DisplayOptions`

### DIFF
--- a/src/types/das-types.ts
+++ b/src/types/das-types.ts
@@ -179,6 +179,7 @@ export namespace DAS {
     showSystemMetadata?: boolean;
     showZeroBalance?: boolean;
     showClosedAccounts?: boolean;
+    showNativeBalance?: boolean;
   };
 
   // Display options for getAssetBatch do not include grand_total.


### PR DESCRIPTION
This PR aims to resolve #129 by adding the `showNativeBalance` field to `DisplayOptions`