### PR TITLE
fix(types): Change `none` to `min`

### DIFF
--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -349,7 +349,7 @@ export interface GetPriorityFeeEstimateRequest {
 }
 
 export interface MicroLamportPriorityFeeLevels {
-  none: number;
+  min: number;
   low: number;
   medium: number;
   high: number;


### PR DESCRIPTION
This PR aims to change the `none` priority fee level to `min`, thereby resolving #140 