### PR TITLE
fix(txts): Explicitly Define `lastValidBlockHeightOffset` for `sendSmartTransaction`

### DIFF
--- a/src/RpcClient.ts
+++ b/src/RpcClient.ts
@@ -722,7 +722,9 @@ export class RpcClient {
       lastValidBlockHeightOffset?: number;
     } = { skipPreflight: false, lastValidBlockHeightOffset: 150 }
   ): Promise<TransactionSignature> {
-    if (sendOptions.lastValidBlockHeightOffset < 0)
+    const lastValidBlockHeightOffset = sendOptions.lastValidBlockHeightOffset ?? 150;
+
+    if (lastValidBlockHeightOffset < 0)
       throw new Error('expiryBlockOffset must be a positive integer');
 
     try {
@@ -767,7 +769,7 @@ export class RpcClient {
               blockhash: blockhash.blockhash,
               lastValidBlockHeight:
                 blockhash.lastValidBlockHeight +
-                sendOptions.lastValidBlockHeightOffset,
+                lastValidBlockHeightOffset,
             },
             commitment
           );


### PR DESCRIPTION
This PR aims to explicitly define `lastValidBlockHeightOffset` for `sendSmartTransaction` all because TypeScript will have a conniption if it isn't. We default `lastValidBlockHeightOffset` to 150 in the function params, but this PR goes a step further to explicitly define it via nullish coalescing to make the compiler happy