### PR TITLE
Removing account webhook type

### DIFF
--- a/src/types/enums.ts
+++ b/src/types/enums.ts
@@ -4,7 +4,6 @@ export enum WebhookType {
   ENHANCED = 'enhanced',
   RAW = 'raw',
   DISCORD = 'discord',
-  ACCOUNT = 'account',
   ENHANCED_DEVNET = 'enhancedDevnet',
   RAW_DEVNET = 'rawDevnet',
   DISCORD_DEVNET = 'discordDevnet',


### PR DESCRIPTION
Account webhooks have no existed for a while, removing it from the sdk types to avoid confusion