### PR TITLE
feat(txs): Add a Priority Fee Cap

### DIFF
--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -2,6 +2,9 @@ import type {
   BlockhashWithExpiryBlockHeight,
   Cluster,
   Keypair,
+  SendOptions,
+  SerializeConfig,
+  Signer,
   Transaction,
   TransactionConfirmationStatus,
   TransactionError,
@@ -370,4 +373,11 @@ export type PollTransactionOptions = {
   timeout?: number; 
   // In milliseconds
   interval?: number;
+}
+
+export interface SmartTransactionOptions extends SendOptions {
+  feePayer?: Signer;
+  lastValidBlockHeightOffset?: number;
+  priorityFeeCap?: number;
+  serializeOptions?: SerializeConfig;
 }


### PR DESCRIPTION
This PR aims to add a priority fee cap for smart transactions. The idea is that the user should be able to cap priority fees at a specific number and use that instead of what is strictly returned by the Priority Fee API. This PR also reworks the send options for smart transactions to make it more intuitive 