### PR TITLE
Add method for parse transactions endpoint

### DIFF
--- a/src/Helius.ts
+++ b/src/Helius.ts
@@ -13,6 +13,8 @@ import {
   RevokeCollectionAuthorityRequest,
   HeliusCluster,
   HeliusEndpoints,
+  ParseTransactionsRequest,
+  ParseTransactionsResponse,
 } from './types';
 
 import axios, { type AxiosError } from 'axios';
@@ -658,5 +660,34 @@ export class Helius {
       TOKEN_METADATA_PROGRAM_ID
     );
     return collectionMetadataAccount;
+  }
+
+  /**
+   * Parse transactions.
+   * @param {ParseTransactionsRequest} params - The request parameters
+   * @returns {Promise<ParseTransactionsResponse>} - Array of parsed transactions
+   * @throws {Error} If there was an error calling the endpoint or too many transactions to parse
+   */
+  async parseTransactions(
+    params: ParseTransactionsRequest
+  ): Promise<ParseTransactionsResponse> {
+    if (params.transactions.length > 100) {
+      throw new Error('The maximum number of transactions to parse is 100');
+    }
+
+    const response = await axios.post(
+      this.getApiEndpoint('/v0/transactions'),
+      {
+        ...params,
+      },
+      {
+        headers: { 'Content-Type': 'application/json' },
+      }
+    );
+    if (response.data.error) {
+      throw new Error(`RPC error: ${JSON.stringify(response.data.error)}`);
+    }
+
+    return response.data as ParseTransactionsResponse;
   }
 }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -376,3 +376,9 @@ export type PollTransactionOptions = {
 export interface HeliusSendOptions extends SolanaWebJsSendOptions {
   validatorAcls?: string[];
 }
+
+export interface ParseTransactionsRequest {
+  transactions: string[];
+}
+
+export type ParseTransactionsResponse = EnrichedTransaction[];


### PR DESCRIPTION
Hi all!

Had a need for experimenting with the parse transactions endpoint and noticed it wasn't implemented in the sdk.
Somebody also explicitly asked for it, so created this PR.
Closes #28