### PR TITLE
fix(types): Change `Omit` to `Exclude`

### DIFF
--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -25,7 +25,7 @@ import type {
   WebhookType,
 } from './enums';
 
-export type HeliusCluster = Omit<Cluster, 'testnet'>;
+export type HeliusCluster = Exclude<Cluster, 'testnet'>;
 
 export type SmartTransactionContext = {
   transaction: Transaction | VersionedTransaction;


### PR DESCRIPTION
This PR aims to fix the `HeliusCluster` type, changing it to use `Exclude` rather than `Omit`. This is because `Omit` is intended for object properties whereas `Exclude` is intended for removing members of a union type, like `Cluster`