### PR TITLE
fix(txs): Already Processed Simulation Error

### DIFF
--- a/src/RpcClient.ts
+++ b/src/RpcClient.ts
@@ -875,6 +875,19 @@ export class RpcClient {
             `pollTransactionConfirmation timed out, attempt #${attemptCount}. Retrying...`
           );
 
+          const status = await this.connection.getSignatureStatus(signature);
+          if (status?.value?.confirmationStatus && !status.value.err) {
+            const { confirmationStatus } = status.value;
+
+            if (["confirmed", "finalized"].includes(confirmationStatus)) {
+              console.info(
+                `Transaction ${signature} was confirmed despite a polling failure. Returning successful now`
+              );
+
+              return signature;
+            }
+          }
+
           await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
           continue;
         }

--- a/src/RpcClient.ts
+++ b/src/RpcClient.ts
@@ -1165,6 +1165,19 @@ export class RpcClient {
             `pollTransactionConfirmation timed out, attempt #${attemptCount}. Retrying...`
           );
 
+          const status = await this.connection.getSignatureStatus(signature);
+          if (status?.value?.confirmationStatus && !status.value.err) {
+            const { confirmationStatus } = status.value;
+
+            if (["confirmed", "finalized"].includes(confirmationStatus)) {
+              console.info(
+                `Transaction ${signature} was confirmed despite a polling failure. Returning successful now`
+              );
+
+              return signature;
+            }
+          }
+
           await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
           continue;
         }


### PR DESCRIPTION
This PR aims to address the issue outlined in #176 by checking whether the transaction was actually confirmed, even if the polling loop timed out, and resolves successfully in that case