### PR TITLE
fix(rpc): Remove `getRwaAsset` Call and Related Types

### DIFF
--- a/src/RpcClient.ts
+++ b/src/RpcClient.ts
@@ -203,39 +203,6 @@ export class RpcClient {
   }
 
   /**
-   * Get RWA Asset by mint.
-   * @param {DAS.GetRwaAssetRequest} - RWA Asset ID
-   * @returns {Promise<DAS.GetRwaAssetResponse>}
-   * @throws {Error}
-   */
-  async getRwaAsset(
-    params: DAS.GetRwaAssetRequest
-  ): Promise<DAS.GetRwaAssetResponse> {
-    try {
-      const url = `${this.connection.rpcEndpoint}`;
-      const response = await axios.post(
-        url,
-        {
-          jsonrpc: '2.0',
-          id: this.id,
-          method: 'getRwaAccountsByMint',
-          params,
-        },
-        {
-          headers: {
-            'Content-Type': 'application/json',
-          },
-        }
-      );
-
-      const { result } = response.data;
-      return result as DAS.GetRwaAssetResponse;
-    } catch (error) {
-      throw new Error(`Error in getRwaAsset: ${error}`);
-    }
-  }
-
-  /**
    * Get multiple assets.
    * @returns {Promise<DAS.GetAssetResponse[]>}
    * @throws {Error}

--- a/src/types/das-types.ts
+++ b/src/types/das-types.ts
@@ -9,7 +9,6 @@ import {
   RoyaltyModel,
   UseMethods,
 } from './enums';
-import { FullRwaAccount } from './types';
 
 export namespace DAS {
   // getAssetsByOwner //
@@ -97,10 +96,6 @@ export namespace DAS {
     id: string;
     displayOptions?: GetAssetDisplayOptions;
   };
-  // getRwaAsset
-  export type GetRwaAssetRequest = {
-    id: string;
-  };
   // getAssetProof
   export type GetAssetProofRequest = {
     id: string;
@@ -141,10 +136,6 @@ export namespace DAS {
     burnt: boolean;
     mint_extensions?: MintExtensions;
     token_info?: TokenInfo;
-  };
-  // RWA Asset Response
-  export type GetRwaAssetResponse = {
-    items: FullRwaAccount;
   };
   export type GetAssetResponseList = {
     grand_total?: number;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -301,49 +301,6 @@ export interface RevokeCollectionAuthorityRequest {
   payerKeypair?: Keypair;
 }
 
-// RWA Asset Types
-interface AssetControllerAccount {
-  address: string;
-  mint: string;
-  authority: string;
-  delegate: string;
-  version: number;
-  closed: boolean;
-}
-
-interface DataRegistryAccount {
-  address: string;
-  mint: string;
-  version: number;
-  closed: boolean;
-}
-
-interface IdentityRegistryAccount {
-  address: string;
-  mint: string;
-  authority: string;
-  delegate: string;
-  version: number;
-  closed: boolean;
-}
-
-interface PolicyEngine {
-  address: string;
-  mint: string;
-  authority: string;
-  delegate: string;
-  policies: string[];
-  version: number;
-  closed: boolean;
-}
-
-export interface FullRwaAccount {
-  asset_controller?: AssetControllerAccount;
-  data_registry?: DataRegistryAccount;
-  identity_registry?: IdentityRegistryAccount;
-  policy_engine?: PolicyEngine;
-}
-
 export interface GetPriorityFeeEstimateOptions {
   priorityLevel?: PriorityLevel;
   includeAllPriorityFeeLevels?: boolean;


### PR DESCRIPTION
This PR aims to remove support for the `getRwaAsset` call as we haven't supported this call in a long-time and I'm surprised we still had it in the SDK lol