### PR TITLE
feat(mintlist): Remove Deprecated Mintlist Calls and Relevant Types

### DIFF
--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -70,25 +70,6 @@ export type EditWebhookRequest = Partial<
   Omit<Webhook, 'webhookID' | 'wallet' | 'project'>
 >;
 
-export interface CreateCollectionWebhookRequest extends CreateWebhookRequest {
-  collectionQuery: CollectionIdentifier;
-}
-
-export interface MintlistResponse {
-  result: MintlistItem[];
-  paginationToken: string;
-}
-
-export type MintlistRequest = {
-  query: CollectionIdentifier;
-  options?: HeliusOptions;
-};
-
-export interface MintlistItem {
-  mint: string;
-  name: string;
-}
-
 export interface RawTokenAmount {
   tokenAmount: string;
   decimals: number;


### PR DESCRIPTION
This PR aims to remove calls to the deprecated mintlist API and all relevant types. Instead, developers should use use the [DAS API](https://www.helius.dev/docs/api-reference/das)