### PR TITLE
Build release

### DIFF
--- a/examples/rpc/getProgramAccountsV2.ts
+++ b/examples/rpc/getProgramAccountsV2.ts
@@ -74,7 +74,7 @@ async function main() {
     'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
     {
       encoding: 'jsonParsed',
-      limit: 100, // Fetch 100 at a time
+      // Note: limit is not configurable for getAllProgramAccounts - it always uses 10000 internally
       filters: [
         { dataSize: 82 }, // Filter for mint accounts (82 bytes) to reduce results
       ]

--- a/examples/rpc/getTokenAccountsByOwnerV2.ts
+++ b/examples/rpc/getTokenAccountsByOwnerV2.ts
@@ -101,8 +101,8 @@ async function main() {
     ownerAddress,
     { programId: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA' },
     {
-      encoding: 'jsonParsed',
-      limit: 100 // Fetch 100 at a time
+      encoding: 'jsonParsed'
+      // Note: limit is not configurable for getAllTokenAccountsByOwner - it always uses 10000 internally
     }
   );
   

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helius-sdk",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "SDK for the Helius API (https://helius.xyz)",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -99,13 +99,5 @@
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
-  },
-  "include": [
-    "src/**/*"
-  ],
-  "exclude": [
-    "examples/**/*",
-    "tests/**/*",
-    "dist/**/*"
-  ]
+  }
 }


### PR DESCRIPTION
Recent addition of include: ["src/**/*"] in tsconfig.json changed TypeScript's build output from dist/src/ to dist/, breaking the package.json entry point.

Removed the include/exclude sections from tsconfig.json to restore the original build behavior, ensuring files are output to dist/src/ as expected by package.json.