### PR TITLE
fix(docs): Make GitHub Happy With Docs Dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The package needs to be configured with your account's API key, which is availab
 
 ```ts
 // Replace imports in a production setting
-import { createHelius } from "../../src/rpc/index";
+import { createHelius } from "helius-sdk";
 
 (async () => {
   const apiKey = ""; // From Helius dashboard
@@ -60,7 +60,7 @@ import { createHelius } from "../../src/rpc/index";
 })();
 ```
 
-### Migrating to helius-sdk 2.0.0
+### Migrating to `helius-sdk` 2.0.0
 The Helius Node.js SDK has been rewritten from the ground up in version 2.0.0 to use [`@solana/kit` (i.e., Kit)](https://www.npmjs.com/package/@solana/kit) under the hood, replacing the dependency on `@solana/web3.js` versions higher than 1.73.2.
 
 We've gone to great lengths to ensure that the developer experience remains largely the same, with minimal impact on existing code. The API methods and namespaces are designed to be intuitive and an improvement on previous versions, so migrating to the latest version is relatively straightforward. There are a plethora of examples found in the `examples` directory, organized by namespace, to aid in this migration.

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,4 @@
+title: Helius SDK
+theme: jekyll-theme-primer
+plugins:
+  - jekyll-redirect-from

--- a/examples/zk/getMultipleNewAddressProofsV2.ts
+++ b/examples/zk/getMultipleNewAddressProofsV2.ts
@@ -25,29 +25,3 @@ import { createHelius } from "helius-sdk";
     console.error("Error with RPC: ", error);
   }
 })();
-
-
-(async () => {
-  const apiKey = "3a4c1aff-f2ac-48a3-b9ca-65814a7bbeb7";
-  const helius = createHelius({ apiKey });
-
-  try {
-  const candidates = [
-    { address: "ARDPkhymCbfdan375FCgPnBJQvUfHeb7nHVdBfwWSxrp", tree: "ARDPkhymCbfdan375FCgPnBJQvUfHeb7nHVdBfwWSxrp" },
-  ];
-
-  const { value } = await helius.zk.getMultipleNewAddressProofsV2(candidates);
-
-  value.forEach((p) =>
-    console.log(
-      p.address,
-      "nextIndex→",
-      p.nextIndex,
-      "isFree→",
-      p.proof.length === 0,
-    ),
-  );
-  } catch (error) {
-    console.error("Error:", error);
-  }
-})();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ES2020",
     "module": "esnext",
     "moduleResolution": "bundler",
+    "rootDir": "./src",
     "outDir": "./dist",
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
This PR aims to make GitHub happy by putting the `docs` dir back in and redirecting it to the README