### PR TITLE
fix(types): Make `ResolvedHeliusRpcApi` Type Explicit

### DIFF
--- a/src/rpc/heliusRpcApi.ts
+++ b/src/rpc/heliusRpcApi.ts
@@ -1,15 +1,5 @@
-import type { createSolanaRpcApi, Rpc, RpcPlan } from "@solana/kit";
+import type { Rpc, SolanaRpcApi } from "@solana/kit";
 import { AutoSent } from "./wrapAutoSend";
 
-// To resolve TS async type issues
-type UnwrapRpcPlan<T> = T extends RpcPlan<infer U> ? U : T;
-
-type UnwrappedRpc<T> = {
-  [K in keyof T]: T[K] extends (...args: infer A) => Promise<infer P>
-    ? (...args: A) => Promise<UnwrapRpcPlan<P>>
-    : T[K];
-};
-
-export type ResolvedHeliusRpcApi = UnwrappedRpc<
-  AutoSent<Rpc<ReturnType<typeof createSolanaRpcApi>>>
->;
+// Concrete type: Matches createSolanaRpcApi(DEFAULT_RPC_CONFIG) → Rpc → AutoSent (unwrapped Promises)
+export type ResolvedHeliusRpcApi = AutoSent<Rpc<SolanaRpcApi>>;

--- a/src/rpc/index.ts
+++ b/src/rpc/index.ts
@@ -105,7 +105,7 @@ export const createHelius = ({
   const transport = createDefaultRpcTransport({ url });
 
   const baseRpc = createRpc({ api: solanaApi, transport });
-  const raw = wrapAutoSend(baseRpc) as unknown as ResolvedHeliusRpcApi;
+  const raw: ResolvedHeliusRpcApi = wrapAutoSend(baseRpc);
 
   const wsUrl = new URL(url);
   wsUrl.protocol = "wss:";


### PR DESCRIPTION
This PR aims to help resolve #214 by making the `ResolvedHeliusRpcApi` type more explicit to resolve `HeliusClient = any` intellisense issues