### PR TITLE
fix(types): Correctly Infer Arg Types for Solana Methods

### DIFF
--- a/src/rpc/wrapAutoSend.ts
+++ b/src/rpc/wrapAutoSend.ts
@@ -24,7 +24,7 @@ export const wrapAutoSend = <T extends Rpc<any>>(raw: T): AutoSent<T> => {
 
       const typedProp = prop as keyof T;
 
-      const wrapper = function (this:any, ...args: any[]) {
+      const wrapper = function (this: any, ...args: any[]) {
         const result = value.apply(this, args);
         return isPending(result) ? result.send() : result;
       };


### PR DESCRIPTION
This PR aims to help resolve #219 as our Proxy leaks the `unknown[]` type into the declaration of methods like `getSignaturesForAddress`

This PR updates the Proxy's `get` trap to create an untyped wrapper inline, and then each wrapper is explicitly cast to `AutoSent<t>[K]` where `K` is the method key. This forces the `.d.ts` to use the inferred signature from `AutoSent`