### PR TITLE
feat(client): Add Rebate Address Support

### DIFF
--- a/src/rpc/createHelius.eager.ts
+++ b/src/rpc/createHelius.eager.ts
@@ -110,13 +110,16 @@ export interface HeliusClientEager {
 export type HeliusRpcOptions = {
   apiKey: string;
   network?: "mainnet" | "devnet";
+  rebateAddress?: string;
 };
 
 export const createHeliusEager = ({
   apiKey,
   network = "mainnet",
+  rebateAddress,
 }: HeliusRpcOptions): HeliusClientEager => {
-  const url = `https://${network}.helius-rpc.com/?api-key=${apiKey}`;
+  const rebateParam = rebateAddress ? `&rebate-address=${rebateAddress}` : "";
+  const url = `https://${network}.helius-rpc.com/?api-key=${apiKey}${rebateParam}`;
 
   const solanaApi = createSolanaRpcApi(DEFAULT_RPC_CONFIG);
   const transport = createDefaultRpcTransport({ url });

--- a/src/rpc/index.ts
+++ b/src/rpc/index.ts
@@ -41,6 +41,7 @@ import { ZkClientLazy } from "../zk/client";
 interface HeliusRpcOptions {
   apiKey: string;
   network?: "mainnet" | "devnet";
+  rebateAddress?: string;
 }
 
 export type HeliusClient = ResolvedHeliusRpcApi & {
@@ -97,9 +98,11 @@ export type HeliusClient = ResolvedHeliusRpcApi & {
 export const createHelius = ({
   apiKey,
   network = "mainnet",
+  rebateAddress,
 }: HeliusRpcOptions): HeliusClient => {
   const baseUrl = `https://${network}.helius-rpc.com/`;
-  const url = `${baseUrl}?api-key=${apiKey}`;
+  const rebateParam = rebateAddress ? `&rebate-address=${rebateAddress}` : "";
+  const url = `${baseUrl}?api-key=${apiKey}${rebateParam}`;
 
   const solanaApi = createSolanaRpcApi(DEFAULT_RPC_CONFIG);
   const transport = createDefaultRpcTransport({ url });


### PR DESCRIPTION
This PR aims to allow users to specify a rebate address during client creation, so users can earn automatic SOL rebates via post-trade backruns for `sendTransaction` calls