### PR TITLE
feat(enhanced-transactions): add new filters and sorting to Get Enhanced Transactions By Address API

### DIFF
--- a/src/enhanced/client.eager.ts
+++ b/src/enhanced/client.eager.ts
@@ -67,17 +67,43 @@ export const makeEnhancedTxClientEager = (
   };
 
   const getTransactionsByAddress: EnhancedTxClient["getTransactionsByAddress"] =
-    async ({ address, before, until, commitment, source, type, limit }) => {
+    async ({
+      address,
+      beforeSignature,
+      afterSignature,
+      commitment,
+      source,
+      type,
+      limit,
+      gtSlot,
+      gteSlot,
+      ltSlot,
+      lteSlot,
+      gtTime,
+      gteTime,
+      ltTime,
+      lteTime,
+      sortOrder,
+    }) => {
       const url =
         `${base}/addresses/${address}/transactions` +
         qs({
           "api-key": apiKey,
-          before,
-          until,
+          "before-signature": beforeSignature,
+          "after-signature": afterSignature,
           commitment,
           source,
           type,
           limit,
+          "gt-slot": gtSlot,
+          "gte-slot": gteSlot,
+          "lt-slot": ltSlot,
+          "lte-slot": lteSlot,
+          "gt-time": gtTime,
+          "gte-time": gteTime,
+          "lt-time": ltTime,
+          "lte-time": lteTime,
+          "sort-order": sortOrder,
         });
 
       const res = await fetch(url, { method: "GET" });

--- a/src/enhanced/tests/getTransactionsByAddress.test.ts
+++ b/src/enhanced/tests/getTransactionsByAddress.test.ts
@@ -39,8 +39,8 @@ describe("Enhanced getTransactionsByAddress Tests", () => {
       commitment: "finalized",
       type: "NFT_SALE",
       source: "MAGIC_EDEN",
-      before: "someSigBefore",
-      until: "someSigUntil",
+      beforeSignature: "someSigBefore",
+      afterSignature: "someSigAfter",
     };
 
     const result = await client.getTransactionsByAddress(params);
@@ -59,8 +59,8 @@ describe("Enhanced getTransactionsByAddress Tests", () => {
     expect(url).toMatch(/type=NFT_SALE/);
     expect(url).toMatch(/source=MAGIC_EDEN/);
     expect(url).toMatch(/commitment=finalized/);
-    expect(url).toMatch(/before=someSigBefore/);
-    expect(url).toMatch(/until=someSigUntil/);
+    expect(url).toMatch(/before-signature=someSigBefore/);
+    expect(url).toMatch(/after-signature=someSigAfter/);
 
     expect(init).toMatchObject({ method: "GET" });
   });

--- a/src/enhanced/types.ts
+++ b/src/enhanced/types.ts
@@ -2,6 +2,7 @@ export type Commitment = "finalized" | "confirmed";
 
 export type TransactionType = string;
 export type TransactionSource = string;
+export type SortOrder = "asc" | "desc";
 
 export interface EnhancedNativeTransfer {
   fromUserAccount: string;
@@ -57,11 +58,20 @@ export type GetEnhancedTransactionsResponse = EnhancedTransaction[];
 /** GET /v0/addresses/:address/transactions */
 export interface GetEnhancedTransactionsByAddressRequest {
   address: string;
-  before?: string;
-  until?: string;
+  beforeSignature?: string;
+  afterSignature?: string;
   commitment?: Commitment;
   source?: TransactionSource;
   type?: TransactionType;
   limit?: number;
+  gtSlot?: number;
+  gteSlot?: number;
+  ltSlot?: number;
+  lteSlot?: number;
+  gtTime?: number;
+  gteTime?: number;
+  ltTime?: number;
+  lteTime?: number;
+  sortOrder?: SortOrder;
 }
 export type GetEnhancedTransactionsByAddressResponse = EnhancedTransaction[];


### PR DESCRIPTION
 - change before/until to before-signature and after-signature
 - add gt/gte/lt/lte-slot/time filters
 - add sorting option via sort-order query param