### PR TITLE
fix(rpc): Rename `includeTokenAccounts` to `tokenAccounts`

### DIFF
--- a/examples/helius/getTransactionsForAddress.ts
+++ b/examples/helius/getTransactionsForAddress.ts
@@ -124,8 +124,8 @@ import { createHelius } from "helius-sdk";
       address,
       {
         limit: 10,
-        includeTokenAccounts: true, // Include transactions from associated token accounts
         filters: {
+          tokenAccounts: "balanceChanged", // Include transactions that modify token account balances
           blockTime: {
             gte: Math.floor(Date.now() / 1000) - (7 * 24 * 60 * 60), // Last 7 days
           },

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -169,47 +169,51 @@ export type GetTransactionsForAddressBaseConfig = {
   limit?: number;
   paginationToken?: string | null;
   sortOrder?: "asc" | "desc";
-  // Include transactions from associated token accounts
-  includeTokenAccounts?: boolean;
   filters?: {
+    /** Filter by transaction status */
     status?: "succeeded" | "failed" | "any";
-    // Filter by slot number
+    /**
+     * Filter transactions for related token accounts:
+     * - `none`: Only return transactions that reference the provided address (default)
+     * - `balanceChanged`: Include transactions that modify token account balances owned by the address (recommended)
+     * - `all`: Include all transactions involving any token account owned by the address
+     */
+    tokenAccounts?: "none" | "balanceChanged" | "all";
+    /** Filter by slot number */
     slot?: {
-      // Equal to
+      /** Equal to */
       eq?: number;
-      // Greater than or equal to
+      /** Greater than or equal to */
       gte?: number;
-      // Greater than
+      /** Greater than */
       gt?: number;
-      // Less than or equal to
+      /** Less than or equal to */
       lte?: number;
-      // Less than
+      /** Less than */
       lt?: number;
     };
-
-    // Filter by block time (Unix timestamp)
+    /** Filter by block time (Unix timestamp) */
     blockTime?: {
-      // Equal to
+      /** Equal to */
       eq?: number;
-      // Greater than or equal to
+      /** Greater than or equal to */
       gte?: number;
-      // Greater than
+      /** Greater than */
       gt?: number;
-      // Less than or equal to
+      /** Less than or equal to */
       lte?: number;
-      // Less than
+      /** Less than */
       lt?: number;
     };
-
-    // Filter by signature (lexicographic comparison)
+    /** Filter by signature (lexicographic comparison) */
     signature?: {
-      // Greater than or equal to
+      /** Greater than or equal to */
       gte?: string;
-      // Greater than
+      /** Greater than */
       gt?: string;
-      // Less than or equal to
+      /** Less than or equal to */
       lte?: string;
-      // Less than
+      /** Less than */
       lt?: string;
     };
   };


### PR DESCRIPTION
This PR aims to rename `includeTokenAccounts` to `tokenAccounts` and puts it under the filters level