### PR TITLE
fix(webhook): Remove header in deleteWebhook (#271)

### DIFF
--- a/src/webhooks/deleteWebhook.ts
+++ b/src/webhooks/deleteWebhook.ts
@@ -9,7 +9,6 @@ export const deleteWebhook = async (
   const response = await fetch(url, {
     method: "DELETE",
     headers: {
-      "Content-Type": "application/json",
       "User-Agent": SDK_USER_AGENT,
     },
   });

--- a/src/webhooks/tests/deleteWebhook.test.ts
+++ b/src/webhooks/tests/deleteWebhook.test.ts
@@ -25,9 +25,6 @@ describe("deleteWebhook Tests", () => {
       `https://api.helius.xyz/v0/webhooks/yavin-base-1138?api-key=test-key`,
       expect.objectContaining({
         method: "DELETE",
-        headers: expect.objectContaining({
-          "Content-Type": "application/json",
-        }),
       })
     );
   });


### PR DESCRIPTION
This PR remove unnecessary header with `"Content-Type": "application/json"` that causes HTTP 400 error.
Closes #271