### PR TITLE
Add escrow monitoring examples

### DIFF
--- a/examples/transactions/escrowWithPriorityFee.ts
+++ b/examples/transactions/escrowWithPriorityFee.ts
@@ -1,0 +1,91 @@
+import { createHelius } from "helius-sdk";
+
+import {
+  address,
+  appendTransactionMessageInstructions,
+  createKeyPairSignerFromBytes,
+  createTransactionMessage,
+  getBase64EncodedWireTransaction,
+  lamports,
+  pipe,
+  setTransactionMessageFeePayerSigner,
+  setTransactionMessageLifetimeUsingBlockhash,
+  signTransactionMessageWithSigners,
+} from "@solana/kit";
+import {
+  getSetComputeUnitLimitInstruction,
+  getSetComputeUnitPriceInstruction,
+} from "@solana-program/compute-budget";
+import { getTransferSolInstruction } from "@solana-program/system";
+import bs58 from "bs58";
+
+const ESCROW_PROGRAM_ID = address("YourEscrowProgram111111111111111111111111111");
+
+(async () => {
+  const apiKey = ""; // From Helius dashboard
+  const helius = createHelius({ apiKey });
+
+  try {
+    const feePayerSigner = await createKeyPairSignerFromBytes(
+      bs58.decode(process.env.FEEPAYER_SECRET ?? "")
+    );
+
+    const escrowAddress = address("EscrowPDA1111111111111111111111111111111111");
+
+    const { priorityFeeEstimate } = await helius.getPriorityFeeEstimate({
+      accountKeys: [escrowAddress, ESCROW_PROGRAM_ID],
+      options: { priorityLevel: "High" },
+    });
+
+    const microLamports = priorityFeeEstimate ?? 0;
+    console.log("Priority fee (µ-lamports/CU):", microLamports);
+
+    // Replace this with your escrow-program instruction (release, refund, dispute, etc).
+    // We're using a plain SOL transfer as a runnable placeholder.
+    const escrowIx = getTransferSolInstruction({
+      amount: lamports(1_000_000n), // 0.001 SOL
+      destination: escrowAddress,
+      source: feePayerSigner,
+    });
+
+    const { value: latestBlockhash } = await helius.getLatestBlockhash();
+
+    const draftMessage = pipe(
+      createTransactionMessage({ version: 0 }),
+      (m) => setTransactionMessageFeePayerSigner(feePayerSigner, m),
+      (m) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, m),
+      (m) => appendTransactionMessageInstructions([escrowIx], m)
+    );
+
+    const units = await helius.tx.getComputeUnits(draftMessage);
+
+    const message = pipe(
+      createTransactionMessage({ version: 0 }),
+      (m) => setTransactionMessageFeePayerSigner(feePayerSigner, m),
+      (m) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, m),
+      (m) =>
+        appendTransactionMessageInstructions(
+          [
+            getSetComputeUnitPriceInstruction({ microLamports }),
+            getSetComputeUnitLimitInstruction({ units }),
+            escrowIx,
+          ] as const,
+          m
+        )
+    );
+
+    const signed = await signTransactionMessageWithSigners(message);
+    const wireTx64 = getBase64EncodedWireTransaction(signed);
+
+    const signature = await helius.tx.sendTransaction(wireTx64, {
+      skipPreflight: true,
+    });
+
+    console.log("Sent:", signature);
+    console.log(
+      `Explorer link: https://orb.helius.dev/tx/${signature}?cluster=mainnet`
+    );
+  } catch (error) {
+    console.error("Error:", error);
+  }
+})();

--- a/examples/webhooks/escrowMonitoring.ts
+++ b/examples/webhooks/escrowMonitoring.ts
@@ -1,0 +1,33 @@
+import { createHelius } from "helius-sdk";
+
+const ESCROW_PROGRAM_ID = "YourEscrowProgram111111111111111111111111111";
+
+(async () => {
+  const apiKey = ""; // From Helius dashboard
+  const helius = createHelius({ apiKey });
+
+  try {
+    const webhook = await helius.webhooks.create({
+      webhookURL: "https://your-server.com/escrow-events",
+      transactionTypes: ["ANY"],
+      accountAddresses: [ESCROW_PROGRAM_ID],
+      webhookType: "enhanced",
+    });
+
+    console.log("Webhook created:", webhook.webhookID);
+
+    const escrowAccounts = [
+      "EscrowPDA1111111111111111111111111111111111",
+      "EscrowPDA2222222222222222222222222222222222",
+    ];
+
+    await helius.webhooks.update(webhook.webhookID, {
+      accountAddresses: [ESCROW_PROGRAM_ID, ...escrowAccounts],
+    });
+
+    console.log("Added escrow accounts");
+  } catch (error) {
+    console.error("Error:", error);
+  }
+})();
+


### PR DESCRIPTION
Adds two examples for escrow monitoring and time-sensitive escrow ops:\n\n- examples/webhooks/escrowMonitoring.ts\n- examples/transactions/escrowWithPriorityFee.ts\n\nThis supersedes #260, updated to use @solana/kit (no @solana/web3.js).