### PR TITLE
feat(webhook): Implement Toggle

### DIFF
--- a/examples/webhooks/toggleWebhook.ts
+++ b/examples/webhooks/toggleWebhook.ts
@@ -1,0 +1,18 @@
+import { createHelius } from "helius-sdk";
+
+(async () => {
+  const apiKey = ""; // From Helius dashboard
+  const helius = createHelius({ apiKey });
+
+  try {
+    // Re-enable an auto-disabled webhook
+    const webhook = await helius.webhooks.toggle(
+      "your_webhook_ID_goes_here",
+      true
+    );
+    console.log("Toggled webhook:", webhook);
+    console.log("Active:", webhook.active);
+  } catch (error) {
+    console.error("Error toggling webhook:", error);
+  }
+})();

--- a/llms.txt
+++ b/llms.txt
@@ -201,6 +201,9 @@ const webhook = await helius.webhooks.create({
 // List all webhooks
 const all = await helius.webhooks.getAll();
 
+// Toggle a webhook on or off (re-enable auto-disabled webhooks, or pause deliveries)
+const toggled = await helius.webhooks.toggle("webhook_id", true);
+
 // Delete a webhook
 await helius.webhooks.delete("webhook_id");
 ```

--- a/src/rpc/index.ts
+++ b/src/rpc/index.ts
@@ -122,6 +122,8 @@ export type HeliusClient = ResolvedHeliusRpcApi & {
     update(webhookID: string, params: UpdateWebhookRequest): Promise<Webhook>;
     /** Delete a webhook by its ID. */
     delete(webhookID: string): Promise<boolean>;
+    /** Enable or disable a webhook without deleting it. Use this to re-enable auto-disabled webhooks or temporarily pause deliveries. */
+    toggle(webhookID: string, active: boolean): Promise<Webhook>;
   } & WebhookClient;
 
   /** Enhanced transaction parsing client. Requires an API key. */

--- a/src/types/webhooks.ts
+++ b/src/types/webhooks.ts
@@ -32,6 +32,8 @@ export interface Webhook {
   webhookType: string;
   /** Authorization header value sent with each webhook delivery request. */
   authHeader: string;
+  /** Whether the webhook is actively receiving deliveries. Webhooks may be automatically disabled if the endpoint has a high failure rate. */
+  active?: boolean;
 }
 
 /** Request parameters for updating an existing webhook. All fields are optional. */

--- a/src/webhooks/client.eager.ts
+++ b/src/webhooks/client.eager.ts
@@ -8,6 +8,7 @@ import { getWebhook } from "./getWebhook";
 import { getAllWebhooks } from "./getAllWebhooks";
 import { updateWebhook } from "./updateWebhook";
 import { deleteWebhook } from "./deleteWebhook";
+import { toggleWebhook } from "./toggleWebhook";
 
 export interface WebhookClient {
   create(params: CreateWebhookRequest): Promise<Webhook>;
@@ -15,6 +16,7 @@ export interface WebhookClient {
   getAll(): Promise<Webhook[]>;
   update(webhookID: string, params: UpdateWebhookRequest): Promise<Webhook>;
   delete(webhookID: string): Promise<boolean>;
+  toggle(webhookID: string, active: boolean): Promise<Webhook>;
 }
 
 export const makeWebhookClientEager = (
@@ -26,4 +28,5 @@ export const makeWebhookClientEager = (
   getAll: () => getAllWebhooks(apiKey, userAgent),
   update: (id, p) => updateWebhook(apiKey, id, p, userAgent),
   delete: (id) => deleteWebhook(apiKey, id, userAgent),
+  toggle: (id, active) => toggleWebhook(apiKey, id, active, userAgent),
 });

--- a/src/webhooks/client.ts
+++ b/src/webhooks/client.ts
@@ -16,6 +16,8 @@ export interface WebhookClient {
   update(webhookID: string, params: UpdateWebhookRequest): Promise<Webhook>;
   /** Delete a webhook. Returns `true` on success. */
   delete(webhookID: string): Promise<boolean>;
+  /** Enable or disable a webhook without deleting it. Use this to re-enable auto-disabled webhooks or temporarily pause deliveries. */
+  toggle(webhookID: string, active: boolean): Promise<Webhook>;
 }
 
 export const makeWebhookClient = (
@@ -37,4 +39,11 @@ export const makeWebhookClient = (
     ),
   delete: async (id) =>
     (await import("./deleteWebhook.js")).deleteWebhook(apiKey, id, userAgent),
+  toggle: async (id, active) =>
+    (await import("./toggleWebhook.js")).toggleWebhook(
+      apiKey,
+      id,
+      active,
+      userAgent
+    ),
 });

--- a/src/webhooks/tests/toggleWebhook.test.ts
+++ b/src/webhooks/tests/toggleWebhook.test.ts
@@ -1,0 +1,103 @@
+import type { Webhook } from "../../types/webhooks";
+import { createHeliusEager as createHelius } from "../../rpc/createHelius.eager";
+
+const mockFetch = jest.fn();
+
+global.fetch = mockFetch as jest.Mock;
+
+describe("toggleWebhook Tests", () => {
+  let rpc: ReturnType<typeof createHelius>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    rpc = createHelius({ apiKey: "test-key" });
+  });
+
+  it("Successfully enables a webhook", async () => {
+    const mockResponse: Webhook = {
+      webhookID: "yavin-base-1138",
+      wallet: "lukeskywalker.sol",
+      webhookURL: "https://rebel-alliance.com/webhook",
+      transactionTypes: ["NFT_SALE"],
+      accountAddresses: ["endor-forest.sol"],
+      webhookType: "enhanced",
+      authHeader: "MayTheForceBeWithYou",
+      active: true,
+    };
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => mockResponse,
+    });
+
+    const result = await rpc.webhooks.toggle("yavin-base-1138", true);
+
+    expect(result).toEqual(mockResponse);
+    expect(result.active).toBe(true);
+    expect(mockFetch).toHaveBeenCalledWith(
+      `https://api.helius.xyz/v0/webhooks/yavin-base-1138?api-key=test-key`,
+      expect.objectContaining({
+        method: "PATCH",
+        headers: expect.objectContaining({
+          "Content-Type": "application/json",
+        }),
+        body: JSON.stringify({ active: true }),
+      })
+    );
+  });
+
+  it("Successfully disables a webhook", async () => {
+    const mockResponse: Webhook = {
+      webhookID: "death-star-plans-66",
+      wallet: "leiaorgana.sol",
+      webhookURL: "https://rebel-alliance.com/webhook",
+      transactionTypes: ["TRANSFER"],
+      accountAddresses: ["alderaan-treasury.sol"],
+      webhookType: "raw",
+      authHeader: "HelpMeObiWan",
+      active: false,
+    };
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => mockResponse,
+    });
+
+    const result = await rpc.webhooks.toggle("death-star-plans-66", false);
+
+    expect(result).toEqual(mockResponse);
+    expect(result.active).toBe(false);
+    expect(mockFetch).toHaveBeenCalledWith(
+      `https://api.helius.xyz/v0/webhooks/death-star-plans-66?api-key=test-key`,
+      expect.objectContaining({
+        method: "PATCH",
+        body: JSON.stringify({ active: false }),
+      })
+    );
+  });
+
+  it("Handles HTTP errors", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      text: async () => "Webhook not found",
+    });
+
+    await expect(rpc.webhooks.toggle("invalid-id", true)).rejects.toThrow(
+      "HTTP error! status: 404 - Webhook not found"
+    );
+  });
+
+  it("Handles Helius API errors", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        error: { code: -32602, message: "Invalid params" },
+      }),
+    });
+
+    await expect(rpc.webhooks.toggle("invalid-id", true)).rejects.toThrow(
+      'Helius error: {"code":-32602,"message":"Invalid params"}'
+    );
+  });
+});

--- a/src/webhooks/toggleWebhook.ts
+++ b/src/webhooks/toggleWebhook.ts
@@ -1,0 +1,32 @@
+import type { Webhook } from "../types/webhooks";
+import { getSDKHeaders } from "../http";
+
+export const toggleWebhook = async (
+  apiKey: string,
+  webhookID: string,
+  active: boolean,
+  userAgent?: string
+): Promise<Webhook> => {
+  const url = `https://api.helius.xyz/v0/webhooks/${webhookID}?api-key=${apiKey}`;
+
+  const response = await fetch(url, {
+    method: "PATCH",
+    headers: {
+      "Content-Type": "application/json",
+      ...getSDKHeaders(userAgent),
+    },
+    body: JSON.stringify({ active }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`HTTP error! status: ${response.status} - ${errorText}`);
+  }
+
+  const data = await response.json();
+  if (data.error) {
+    throw new Error(`Helius error: ${JSON.stringify(data.error)}`);
+  }
+
+  return data as Webhook;
+};


### PR DESCRIPTION
This PR adds a new `helius.webhooks.toggle(webhookID, active)` method that calls `PATCH /v0/webhooks/{webhookID}` to enable / disable a webhook without deleting it