### PR TITLE
fix(auth): map basic plan to basic_v4 usage plan key

### DIFF
--- a/src/auth/constants.ts
+++ b/src/auth/constants.ts
@@ -18,7 +18,7 @@ export const PAYMENT_AMOUNT = 1_000_000n;
 
 /** Maps plan catalog keys to the keys returned by /dev-portal/configs openPay.priceIds */
 export const PLAN_TO_USAGE_PLAN: Record<string, string> = {
-  basic: "basic",
+  basic: "basic_v4",
   developer: "developer_v4",
   business: "business_v4",
   professional: "professional_v4",

--- a/src/auth/tests/checkout.test.ts
+++ b/src/auth/tests/checkout.test.ts
@@ -60,13 +60,13 @@ const mockPaySponsoredIntent = paySponsoredIntent as jest.MockedFunction<
 
 const MOCK_PRICE_IDS = {
   Monthly: {
-    basic: "price_basic_monthly",
+    basic_v4: "price_basic_monthly",
     developer_v4: "price_dev_monthly",
     business_v4: "price_biz_monthly",
     professional_v4: "price_pro_monthly",
   },
   Yearly: {
-    basic: "price_basic_yearly",
+    basic_v4: "price_basic_yearly",
     developer_v4: "price_dev_yearly",
     business_v4: "price_biz_yearly",
     professional_v4: "price_pro_yearly",


### PR DESCRIPTION
## Summary

- Maps `basic` → `"basic_v4"` in `PLAN_TO_USAGE_PLAN` to match the backend's OpenPay config key

## Related PRs

- Monorepo: https://github.com/helius-labs/monorepo/pull/14357

## Test plan

- [ ] `helius signup` resolves the basic plan priceId without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)