### PR TITLE
feat(auth): revert basic plan to direct signup with sponsored SOL

### DIFF
--- a/src/auth/agenticSignup.ts
+++ b/src/auth/agenticSignup.ts
@@ -8,8 +8,7 @@ import { getProject } from "./getProject";
 import { executeCheckout } from "./checkout";
 import { OPENPAY_PLANS } from "./constants";
 import { isOpenPayPlan, buildEndpoints } from "./signupHelpers";
-
-const ALL_PLANS = ["basic", ...OPENPAY_PLANS];
+import { executeBasicSignup } from "./basicSignup";
 
 export async function agenticSignup(
   options: AgenticSignupOptions
@@ -23,7 +22,7 @@ export async function agenticSignup(
   // Validate plan
   if (plan !== "basic" && !isOpenPayPlan(plan)) {
     throw new Error(
-      `Unknown plan: ${plan}. Available: ${ALL_PLANS.join(", ")}`
+      `Unknown plan: ${plan}. Available: basic, ${OPENPAY_PLANS.join(", ")}`
     );
   }
 
@@ -105,7 +104,7 @@ export async function agenticSignup(
     };
   }
 
-  // ── New user paths ── All plans go through checkout
+  // ── New user paths ──
 
   if (isOpenPayPlan(plan)) {
     // Validate required contact info for new subscriptions
@@ -120,50 +119,52 @@ export async function agenticSignup(
           `Pass --email, --first-name, and --last-name.`
       );
     }
-  }
 
-  // Checkout for all plans (basic, developer, business, professional)
-  // Always use sponsored mode — payPaymentIntent falls back to self-funded if needed
-  const checkoutResult = await executeCheckout(
-    secretKey,
-    jwt,
-    {
-      plan,
-      period: options.period ?? "monthly",
-      refId: auth.refId,
-      email,
-      firstName,
-      lastName,
+    // OpenPay checkout for developer/business/professional
+    const checkoutResult = await executeCheckout(
+      secretKey,
+      jwt,
+      {
+        plan,
+        period: options.period ?? "monthly",
+        refId: auth.refId,
+        email,
+        firstName,
+        lastName,
+        walletAddress,
+        couponCode: options.couponCode,
+        paymentMode: "sponsored",
+      },
+      userAgent
+    );
+
+    if (checkoutResult.status !== "completed") {
+      throw new Error(
+        `Checkout ${checkoutResult.status}${checkoutResult.error ? `: ${checkoutResult.error}` : ""}${checkoutResult.txSignature ? `. TX: ${checkoutResult.txSignature}` : ""}`
+      );
+    }
+
+    if (!checkoutResult.projectId) {
+      throw new Error(
+        "Checkout completed but no project was provisioned. " +
+          `Payment intent: ${checkoutResult.paymentIntentId}`
+      );
+    }
+
+    return {
+      status: "success",
+      jwt,
       walletAddress,
-      couponCode: options.couponCode,
-      paymentMode: "sponsored",
-    },
-    userAgent
-  );
-
-  if (checkoutResult.status !== "completed") {
-    throw new Error(
-      `Checkout ${checkoutResult.status}${checkoutResult.error ? `: ${checkoutResult.error}` : ""}${checkoutResult.txSignature ? `. TX: ${checkoutResult.txSignature}` : ""}`
-    );
+      projectId: checkoutResult.projectId,
+      apiKey: checkoutResult.apiKey || null,
+      endpoints: checkoutResult.apiKey
+        ? buildEndpoints(checkoutResult.apiKey)
+        : null,
+      credits: null,
+      txSignature: checkoutResult.txSignature ?? undefined,
+    };
   }
 
-  if (!checkoutResult.projectId) {
-    throw new Error(
-      "Checkout completed but no project was provisioned. " +
-        `Payment intent: ${checkoutResult.paymentIntentId}`
-    );
-  }
-
-  return {
-    status: "success",
-    jwt,
-    walletAddress,
-    projectId: checkoutResult.projectId,
-    apiKey: checkoutResult.apiKey || null,
-    endpoints: checkoutResult.apiKey
-      ? buildEndpoints(checkoutResult.apiKey)
-      : null,
-    credits: null,
-    txSignature: checkoutResult.txSignature ?? undefined,
-  };
+  // Basic plan ($1 USDC) → sponsored payment → createProject
+  return executeBasicSignup(secretKey, jwt, walletAddress, userAgent);
 }

--- a/src/auth/basicSignup.ts
+++ b/src/auth/basicSignup.ts
@@ -32,8 +32,11 @@ export async function executeBasicSignup(
   // 2. Try sponsored path (no SOL needed)
   let txSignature: string;
   try {
-    const { transaction, lastValidBlockHeight } =
-      await requestBasicSponsoredTx(jwt, walletAddress, userAgent);
+    const { transaction, lastValidBlockHeight } = await requestBasicSponsoredTx(
+      jwt,
+      walletAddress,
+      userAgent
+    );
     txSignature = await signAndSubmitSponsoredTx(
       secretKey,
       transaction,

--- a/src/auth/basicSignup.ts
+++ b/src/auth/basicSignup.ts
@@ -1,0 +1,80 @@
+import type { AgenticSignupResult } from "./types";
+import { checkSolBalance, checkUsdcBalance } from "./checkBalances";
+import { payUSDC } from "./payUSDC";
+import { requestBasicSponsoredTx } from "./basicSponsoredPayment";
+import { signAndSubmitSponsoredTx } from "./sponsoredPayment";
+import { createProject } from "./createProject";
+import { getProject } from "./getProject";
+import { retryWithBackoff } from "./retry";
+import { getHttpStatus } from "./getHttpStatus";
+import { buildEndpoints } from "./signupHelpers";
+import { MIN_SOL_FOR_TX, PAYMENT_AMOUNT } from "./constants";
+
+/**
+ * Basic plan signup: $1 USDC direct payment with sponsored SOL.
+ * Tries sponsored transaction first (backend pays SOL fees),
+ * falls back to self-funded payUSDC if sponsorship infra fails.
+ */
+export async function executeBasicSignup(
+  secretKey: Uint8Array,
+  jwt: string,
+  walletAddress: string,
+  userAgent: string | undefined
+): Promise<AgenticSignupResult> {
+  // 1. Check USDC balance (user pays $1)
+  const usdcBalance = await checkUsdcBalance(walletAddress);
+  if (usdcBalance < PAYMENT_AMOUNT) {
+    throw new Error(
+      `Insufficient USDC. Have: ${Number(usdcBalance) / 1_000_000} USDC, need: 1 USDC. Fund address: ${walletAddress}`
+    );
+  }
+
+  // 2. Try sponsored path (no SOL needed)
+  let txSignature: string;
+  try {
+    const { transaction, lastValidBlockHeight } =
+      await requestBasicSponsoredTx(jwt, walletAddress, userAgent);
+    txSignature = await signAndSubmitSponsoredTx(
+      secretKey,
+      transaction,
+      BigInt(lastValidBlockHeight)
+    );
+  } catch (err) {
+    // USDC errors re-throw — self-funded fallback would fail identically
+    if (err instanceof Error && err.message.includes("Insufficient USDC"))
+      throw err;
+    // 4xx errors are permanent — self-funding won't help
+    const status = getHttpStatus(err);
+    if (status !== undefined && status >= 400 && status < 500) throw err;
+
+    // 3. Sponsorship infra issue (5xx / network) — fall back to self-funded
+    console.warn(
+      `[helius-sdk] Sponsored basic payment failed, falling back to self-funded: ${err instanceof Error ? err.message : String(err)}`
+    );
+    const solBalance = await checkSolBalance(walletAddress);
+    if (solBalance < MIN_SOL_FOR_TX) {
+      throw new Error(
+        `Insufficient SOL for transaction fees. Have: ${Number(solBalance) / 1_000_000_000} SOL, need: ~0.001 SOL. Fund address: ${walletAddress}`
+      );
+    }
+    txSignature = await payUSDC(secretKey);
+  }
+
+  // 4. Create project (verifies USDC transfer on-chain via RPC)
+  const project = await retryWithBackoff(() => createProject(jwt, userAgent));
+
+  const projectDetails = await getProject(jwt, project.id, userAgent);
+  const apiKey =
+    projectDetails.apiKeys?.[0]?.keyId || project.apiKeys?.[0]?.keyId || null;
+
+  return {
+    status: "success",
+    jwt,
+    walletAddress,
+    projectId: project.id,
+    apiKey,
+    endpoints: apiKey ? buildEndpoints(apiKey) : null,
+    credits: projectDetails.creditsUsage?.remainingCredits ?? null,
+    txSignature,
+  };
+}

--- a/src/auth/basicSponsoredPayment.ts
+++ b/src/auth/basicSponsoredPayment.ts
@@ -1,0 +1,27 @@
+import { authRequest } from "./utils";
+
+interface BasicSponsoredTxResponse {
+  transaction: string;
+  lastValidBlockHeight: number;
+}
+
+/**
+ * Requests a sponsored transaction for basic plan signup ($1 USDC).
+ * The backend builds the transaction and signs as fee payer —
+ * the caller only needs to add their signature and submit.
+ */
+export async function requestBasicSponsoredTx(
+  jwt: string,
+  walletAddress: string,
+  userAgent?: string
+): Promise<BasicSponsoredTxResponse> {
+  return authRequest<BasicSponsoredTxResponse>(
+    "/signup/build-basic-sponsored-tx",
+    {
+      method: "POST",
+      headers: { Authorization: `Bearer ${jwt}` },
+      body: JSON.stringify({ walletAddress }),
+    },
+    userAgent
+  );
+}

--- a/src/auth/constants.ts
+++ b/src/auth/constants.ts
@@ -18,7 +18,6 @@ export const PAYMENT_AMOUNT = 1_000_000n;
 
 /** Maps plan catalog keys to the keys returned by /dev-portal/configs openPay.priceIds */
 export const PLAN_TO_USAGE_PLAN: Record<string, string> = {
-  basic: "basic",
   developer: "developer_v4",
   business: "business_v4",
   professional: "professional_v4",

--- a/src/auth/tests/agenticSignup.test.ts
+++ b/src/auth/tests/agenticSignup.test.ts
@@ -57,9 +57,26 @@ jest.mock("../checkout", () => ({
   }),
 }));
 
+jest.mock("../basicSignup", () => ({
+  executeBasicSignup: jest.fn().mockResolvedValue({
+    status: "success",
+    jwt: "jwt-token-123",
+    walletAddress: "WalletAddress123",
+    projectId: "proj-new",
+    apiKey: "key-abc",
+    endpoints: {
+      mainnet: "https://mainnet.helius-rpc.com/?api-key=key-abc",
+      devnet: "https://devnet.helius-rpc.com/?api-key=key-abc",
+    },
+    credits: null,
+    txSignature: "tx-sig-basic123",
+  }),
+}));
+
 import { agenticSignup } from "../agenticSignup";
 import { listProjects } from "../listProjects";
 import { executeCheckout, executeUpgrade } from "../checkout";
+import { executeBasicSignup } from "../basicSignup";
 
 const EXISTING_PROJECT = {
   id: "proj-existing",
@@ -76,10 +93,10 @@ describe("agenticSignup", () => {
     jest.clearAllMocks();
   });
 
-  // ── Basic plan (now via checkout) ──
+  // ── Basic plan (via executeBasicSignup) ──
 
-  describe("basic plan (via checkout)", () => {
-    it("creates a new project via checkout when no plan specified", async () => {
+  describe("basic plan (direct signup)", () => {
+    it("calls executeBasicSignup when no plan specified", async () => {
       const result = await agenticSignup({ secretKey: new Uint8Array(64) });
 
       expect(result.status).toBe("success");
@@ -87,50 +104,32 @@ describe("agenticSignup", () => {
       expect(result.walletAddress).toBe("WalletAddress123");
       expect(result.projectId).toBe("proj-new");
       expect(result.apiKey).toBe("key-abc");
-      expect(result.txSignature).toBe("tx-sig-abc123");
-      expect(result.endpoints).toEqual({
-        mainnet: "https://mainnet.helius-rpc.com/?api-key=key-abc",
-        devnet: "https://devnet.helius-rpc.com/?api-key=key-abc",
-      });
+      expect(result.txSignature).toBe("tx-sig-basic123");
 
-      expect(executeCheckout).toHaveBeenCalledWith(
+      expect(executeBasicSignup).toHaveBeenCalledWith(
         new Uint8Array(64),
         "jwt-token-123",
-        {
-          plan: "basic",
-          period: "monthly",
-          refId: "ref-1",
-          email: undefined,
-          firstName: undefined,
-          lastName: undefined,
-          walletAddress: "WalletAddress123",
-          couponCode: undefined,
-          paymentMode: "sponsored",
-        },
+        "WalletAddress123",
         undefined
       );
+      expect(executeCheckout).not.toHaveBeenCalled();
     });
 
-    it("creates a new project via checkout when plan='basic'", async () => {
-      const result = await agenticSignup({
+    it("calls executeBasicSignup when plan='basic'", async () => {
+      await agenticSignup({
         secretKey: new Uint8Array(64),
         plan: "basic",
       });
 
-      expect(result.status).toBe("success");
-      expect(executeCheckout).toHaveBeenCalledWith(
-        expect.any(Uint8Array),
-        "jwt-token-123",
-        expect.objectContaining({ plan: "basic" }),
-        undefined
-      );
+      expect(executeBasicSignup).toHaveBeenCalled();
+      expect(executeCheckout).not.toHaveBeenCalled();
     });
 
     it("treats empty string plan as basic", async () => {
       await agenticSignup({ secretKey: new Uint8Array(64), plan: "" });
 
-      const callArgs = (executeCheckout as jest.Mock).mock.calls[0];
-      expect(callArgs[2].plan).toBe("basic");
+      expect(executeBasicSignup).toHaveBeenCalled();
+      expect(executeCheckout).not.toHaveBeenCalled();
     });
 
     it("returns existing project when one exists (basic plan)", async () => {
@@ -140,38 +139,20 @@ describe("agenticSignup", () => {
 
       expect(result.status).toBe("existing_project");
       expect(result.projectId).toBe("proj-existing");
+      expect(executeBasicSignup).not.toHaveBeenCalled();
       expect(executeCheckout).not.toHaveBeenCalled();
-      expect(executeUpgrade).not.toHaveBeenCalled();
     });
 
-    it("always sets paymentMode to sponsored for new signups", async () => {
-      await agenticSignup({
-        secretKey: new Uint8Array(64),
-      });
-
-      const callArgs = (executeCheckout as jest.Mock).mock.calls[0];
-      expect(callArgs[2].paymentMode).toBe("sponsored");
-    });
-
-    it("passes userAgent through to checkout flow", async () => {
-      const { walletSignup } = require("../walletSignup");
-
+    it("passes userAgent through to basic signup", async () => {
       await agenticSignup({
         secretKey: new Uint8Array(64),
         userAgent: "test-agent/1.0",
       });
 
-      expect(walletSignup).toHaveBeenCalledWith(
-        "auth-msg",
-        "auth-sig",
-        "WalletAddress123",
-        "test-agent/1.0"
-      );
-
-      expect(executeCheckout).toHaveBeenCalledWith(
+      expect(executeBasicSignup).toHaveBeenCalledWith(
         new Uint8Array(64),
         "jwt-token-123",
-        expect.objectContaining({ plan: "basic", paymentMode: "sponsored" }),
+        "WalletAddress123",
         "test-agent/1.0"
       );
     });

--- a/src/auth/tests/checkout.test.ts
+++ b/src/auth/tests/checkout.test.ts
@@ -60,13 +60,11 @@ const mockPaySponsoredIntent = paySponsoredIntent as jest.MockedFunction<
 
 const MOCK_PRICE_IDS = {
   Monthly: {
-    basic: "price_basic_monthly",
     developer_v4: "price_dev_monthly",
     business_v4: "price_biz_monthly",
     professional_v4: "price_pro_monthly",
   },
   Yearly: {
-    basic: "price_basic_yearly",
     developer_v4: "price_dev_yearly",
     business_v4: "price_biz_yearly",
     professional_v4: "price_pro_yearly",
@@ -96,12 +94,6 @@ const POLL_COMPLETED_RESPONSE = {
 describe("resolvePriceId", () => {
   beforeEach(() => jest.resetAllMocks());
 
-  it("resolves basic monthly", async () => {
-    mockFetchOpenPayPriceIds.mockResolvedValue(MOCK_PRICE_IDS);
-    const result = await resolvePriceId("jwt", "basic", "monthly");
-    expect(result).toBe("price_basic_monthly");
-  });
-
   it("resolves developer monthly", async () => {
     mockFetchOpenPayPriceIds.mockResolvedValue(MOCK_PRICE_IDS);
     const result = await resolvePriceId("jwt", "developer", "monthly");
@@ -128,7 +120,7 @@ describe("resolvePriceId", () => {
 
   it("includes available plans in error", async () => {
     await expect(resolvePriceId("jwt", "invalid", "monthly")).rejects.toThrow(
-      "Available: basic, developer, business, professional"
+      "Available: developer, business, professional"
     );
   });
 
@@ -633,7 +625,7 @@ describe("initializeSignupFunding", () => {
     mockAuthRequest.mockResolvedValue(INIT_RESPONSE);
 
     const funding = await initializeSignupFunding("jwt", {
-      plan: "basic",
+      plan: "developer",
       period: "monthly",
       refId: "ref-1",
     });


### PR DESCRIPTION
## Summary

- Basic plan no longer goes through the checkout/OpenPay flow
- New `executeBasicSignup` path: sponsored tx first (backend pays SOL fees), self-funded `payUSDC` fallback
- Paid plans (developer/business/professional) keep checkout + sponsored mode unchanged
- Removes `basic` from `PLAN_TO_USAGE_PLAN` — no checkout priceId needed

## New files

- `basicSponsoredPayment.ts` — calls `POST /signup/build-basic-sponsored-tx` (new backend endpoint, separate PR)
- `basicSignup.ts` — sponsored-first + payUSDC fallback + createProject

## Related PRs

- Monorepo revert: helius-labs/monorepo#14376 (removes BASIC_V4 from checkout flow)
- Monorepo follow-up: new `POST /signup/build-basic-sponsored-tx` endpoint (TBD)
- Core AI: CLI hardcodes $1 for basic plan (same branch)

## Test plan

- [x] 397/397 SDK tests pass
- [ ] E2E: `helius signup --wait` completes basic plan via sponsored path
- [ ] E2E: fallback to self-funded works when sponsorship endpoint unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)