### PR TITLE
docs: update LaserStream pricing and business plan access

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -261,7 +261,7 @@ const updates = await helius.getProgramAccountsV2([
 | RPC Rate Limit | 10 req/s | 50 req/s | 200 req/s | 500 req/s |
 | DAS & Enhanced API | 2 req/s | 10 req/s | 50 req/s | 100 req/s |
 | Helius Sender | 15/s | 15/s | 15/s | 15/s |
-| Enhanced WebSockets | No | No | Yes | Yes |
+| Enhanced WebSockets | No | Yes | Yes | Yes |
 | LaserStream gRPC (2 credits/0.1mb) | No | Devnet | Devnet + Mainnet | Devnet + Mainnet |
 
 Monitor usage via the [Helius CLI](https://www.helius.dev/docs/api-reference/helius-cli) using the command `helius usage --json`. Verify current limits at https://docs.helius.dev — the table above may be outdated.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -262,7 +262,7 @@ const updates = await helius.getProgramAccountsV2([
 | DAS & Enhanced API | 2 req/s | 10 req/s | 50 req/s | 100 req/s |
 | Helius Sender | 15/s | 15/s | 15/s | 15/s |
 | Enhanced WebSockets | No | No | Yes | Yes |
-| LaserStream gRPC | No | Devnet | Devnet | Devnet + Mainnet |
+| LaserStream gRPC (2 credits/0.1mb) | No | Devnet | Devnet + Mainnet | Devnet + Mainnet |
 
 Monitor usage via the [Helius CLI](https://www.helius.dev/docs/api-reference/helius-cli) using the command `helius usage --json`. Verify current limits at https://docs.helius.dev — the table above may be outdated.
 

--- a/llms.txt
+++ b/llms.txt
@@ -341,7 +341,7 @@ try {
 | Standard WebSockets Availability | ✓ | ✓ | ✓ | ✓ |
 | Helius Enhanced WebSockets Availability | No | No | ✓ | ✓ |
 | Helius Sender Availability | ✓ | ✓ | ✓ | ✓ |
-| Helius LaserStream gRPC Availability | No | Devnet | Devnet | Devnet, Mainnet |
+| Helius LaserStream gRPC Availability (2 credits/0.1mb) | No | Devnet | Devnet + Mainnet | Devnet + Mainnet |
 | Support | Community | Chat | Priority Chat | Slack/Telegram |
 
 - When you receive a 429 error, back off and retry with exponential delay

--- a/llms.txt
+++ b/llms.txt
@@ -339,7 +339,7 @@ try {
 | DAS API and Enhanced API Rate Limits | 2 req/s | 10 req/s | 50 req/s | 100 req/s |
 | Sender Rate Limits | 15/s | 15/s | 15/s | 15/s |
 | Standard WebSockets Availability | ✓ | ✓ | ✓ | ✓ |
-| Helius Enhanced WebSockets Availability | No | No | ✓ | ✓ |
+| Helius Enhanced WebSockets Availability | No | ✓ | ✓ | ✓ |
 | Helius Sender Availability | ✓ | ✓ | ✓ | ✓ |
 | Helius LaserStream gRPC Availability (2 credits/0.1mb) | No | Devnet | Devnet + Mainnet | Devnet + Mainnet |
 | Support | Community | Chat | Priority Chat | Slack/Telegram |


### PR DESCRIPTION
## Summary
- Updated LaserStream pricing to 2 credits / 0.1mb in plan tables
- Expanded Business plan access to Devnet + Mainnet (previously Devnet only)
- Changes reflected in both `AGENTS.md` and `llms.txt`

## Test plan
- [ ] Verify plan table values match current Helius pricing page

🤖 Generated with [Claude Code](https://claude.com/claude-code)