### PR TITLE
Adds initial Admin API support to `helius-sdk`

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,3 +257,16 @@ Query wallet data including identity, balances, history, and transfers. Availabl
 - [`getHistory()`](https://www.helius.dev/docs/api-reference/wallet-api/history): Fetch transaction history with balance changes and pagination
 - [`getTransfers()`](https://www.helius.dev/docs/api-reference/wallet-api/transfers): Get all token transfer activity with sender/recipient information
 - [`getFundedBy()`](https://www.helius.dev/docs/api-reference/wallet-api/funded-by): Discover the original funding source for a wallet
+
+[**Admin API**](https://www.helius.dev/docs/admin-api)
+
+Query project-level administrative data that is authenticated with an API key and served from `https://admin-api.helius.xyz/v0`. Available on the `helius.admin` namespace.
+
+Admin API access is feature-gated per project. The API key must belong to the same project as the `projectId` you request.
+
+- [`getProjectUsage(projectId)`](https://www.helius.dev/docs/api-reference/admin-api/project-usage): Get current billing-period credit usage, remaining credits, prepaid credits, and per-product usage breakdown for a project.
+
+Examples:
+
+- [`examples/admin/getProjectUsage.ts`](https://github.com/helius-labs/helius-sdk/blob/main/examples/admin/getProjectUsage.ts): Use the root SDK client via `createHelius({ apiKey })`
+- [`examples/admin/makeAdminClient.ts`](https://github.com/helius-labs/helius-sdk/blob/main/examples/admin/makeAdminClient.ts): Use the direct admin client import via `helius-sdk/admin/client`

--- a/bundlemon.config.js
+++ b/bundlemon.config.js
@@ -20,6 +20,10 @@ export default {
       maxSize: '1.5kb',
     },
     {
+      path: 'dist/esm/rpc/index.js',
+      maxSize: '2.52kb',
+    },
+    {
       path: 'dist/esm/websockets/wsAsync.js',
       maxSize: '1.5kb',
     },

--- a/examples/admin/getProjectUsage.ts
+++ b/examples/admin/getProjectUsage.ts
@@ -1,0 +1,42 @@
+import { createHelius } from "helius-sdk";
+
+(async () => {
+  const apiKey = ""; // From Helius dashboard
+  const projectId = ""; // UUID of the project associated with the API key
+  const helius = createHelius({ apiKey });
+
+  try {
+    const usage = await helius.admin.getProjectUsage(projectId);
+
+    console.log("\nProject Usage:");
+    console.log("=".repeat(80));
+    console.log(`Project ID: ${projectId}`);
+    console.log(`Credits Used: ${usage.creditsUsed}`);
+    console.log(`Credits Remaining: ${usage.creditsRemaining}`);
+    console.log(`Prepaid Credits Used: ${usage.prepaidCreditsUsed}`);
+    console.log(
+      `Prepaid Credits Remaining: ${usage.prepaidCreditsRemaining}`
+    );
+
+    console.log("\nSubscription Details:");
+    console.log(`Plan: ${usage.subscriptionDetails.plan}`);
+    console.log(`Credits Limit: ${usage.subscriptionDetails.creditsLimit}`);
+    console.log(
+      `Billing Cycle: ${usage.subscriptionDetails.billingCycle.start} → ${usage.subscriptionDetails.billingCycle.end}`
+    );
+
+    console.log("\nUsage Breakdown:");
+    console.log(`RPC: ${usage.usage.rpc}`);
+    console.log(`DAS: ${usage.usage.das}`);
+    console.log(`Webhooks: ${usage.usage.webhook}`);
+    console.log(`WebSockets: ${usage.usage.websocket}`);
+    console.log(`API: ${usage.usage.api}`);
+    console.log(`gRPC: ${usage.usage.grpc}`);
+    console.log(`gRPC Geyser: ${usage.usage.grpcGeyser}`);
+    console.log(`Archival: ${usage.usage.archival}`);
+    console.log(`Photon: ${usage.usage.photon}`);
+    console.log(`Stream: ${usage.usage.stream}`);
+  } catch (error: any) {
+    console.error("\nError fetching project usage:", error.message);
+  }
+})();

--- a/examples/admin/makeAdminClient.ts
+++ b/examples/admin/makeAdminClient.ts
@@ -1,0 +1,23 @@
+import { makeAdminClient } from "helius-sdk/admin/client";
+
+(async () => {
+  const apiKey = ""; // From Helius dashboard
+  const projectId = ""; // UUID of the project associated with the API key
+  const admin = makeAdminClient(apiKey);
+
+  try {
+    const usage = await admin.getProjectUsage(projectId);
+
+    console.log("\nAdmin Client Project Usage:");
+    console.log("=".repeat(80));
+    console.log(`Project ID: ${projectId}`);
+    console.log(`Credits Used: ${usage.creditsUsed}`);
+    console.log(`Credits Remaining: ${usage.creditsRemaining}`);
+    console.log(
+      `Billing Cycle: ${usage.subscriptionDetails.billingCycle.start} → ${usage.subscriptionDetails.billingCycle.end}`
+    );
+    console.log(`Plan: ${usage.subscriptionDetails.plan}`);
+  } catch (error: any) {
+    console.error("\nError fetching project usage:", error.message);
+  }
+})();

--- a/package.json
+++ b/package.json
@@ -74,6 +74,11 @@
       "import": "./dist/esm/auth/*.js",
       "require": "./dist/cjs/auth/*.cjs"
     },
+    "./admin/*": {
+      "types": "./dist/esm/admin/*.d.ts",
+      "import": "./dist/esm/admin/*.js",
+      "require": "./dist/cjs/admin/*.cjs"
+    },
     "./package.json": "./package.json"
   },
   "sideEffects": false,

--- a/src/admin/client.eager.ts
+++ b/src/admin/client.eager.ts
@@ -1,0 +1,13 @@
+import type { AdminClient } from "./client";
+import type { ProjectUsage } from "./types";
+import { getProjectUsage } from "./getProjectUsage";
+
+export type { AdminClient };
+
+export const makeAdminClientEager = (
+  apiKey: string,
+  userAgent?: string
+): AdminClient => ({
+  getProjectUsage: (projectId: string): Promise<ProjectUsage> =>
+    getProjectUsage(apiKey, projectId, userAgent),
+});

--- a/src/admin/client.ts
+++ b/src/admin/client.ts
@@ -1,0 +1,19 @@
+import type { ProjectUsage } from "./types";
+
+/** Client for API-key authenticated Admin API endpoints. */
+export interface AdminClient {
+  /** Get credit usage for the current billing period for a project tied to the API key. */
+  getProjectUsage(projectId: string): Promise<ProjectUsage>;
+}
+
+export const makeAdminClient = (
+  apiKey: string,
+  userAgent?: string
+): AdminClient => ({
+  getProjectUsage: async (projectId) =>
+    (await import("./getProjectUsage.js")).getProjectUsage(
+      apiKey,
+      projectId,
+      userAgent
+    ),
+});

--- a/src/admin/constants.ts
+++ b/src/admin/constants.ts
@@ -1,0 +1,1 @@
+export const ADMIN_API_URL = "https://admin-api.helius.xyz/v0";

--- a/src/admin/getProjectUsage.ts
+++ b/src/admin/getProjectUsage.ts
@@ -1,0 +1,17 @@
+import type { ProjectUsage } from "./types";
+import { adminRequest } from "./utils";
+
+export async function getProjectUsage(
+  apiKey: string,
+  projectId: string,
+  userAgent?: string
+): Promise<ProjectUsage> {
+  return adminRequest<ProjectUsage>(
+    apiKey,
+    `/admin/projects/${encodeURIComponent(projectId)}/usage`,
+    {
+      method: "GET",
+    },
+    userAgent
+  );
+}

--- a/src/admin/tests/client.test.ts
+++ b/src/admin/tests/client.test.ts
@@ -1,0 +1,66 @@
+import { makeAdminClient } from "../client";
+import { makeAdminClientEager } from "../client.eager";
+import { ADMIN_API_URL } from "../constants";
+import type { ProjectUsage } from "../types";
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch as jest.Mock;
+
+describe("makeAdminClient", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("exports a direct admin client with getProjectUsage", () => {
+    const admin = makeAdminClient("test-key");
+
+    expect(typeof admin.getProjectUsage).toBe("function");
+  });
+
+  it("calls the admin usage endpoint directly via the eager client", async () => {
+    const admin = makeAdminClientEager("test-key", "helius-sdk-tests/1.0.0");
+
+    const mockUsage: ProjectUsage = {
+      creditsRemaining: 999080,
+      creditsUsed: 920,
+      prepaidCreditsRemaining: 5000,
+      prepaidCreditsUsed: 120,
+      subscriptionDetails: {
+        billingCycle: { start: "2026-04-01", end: "2026-05-01" },
+        creditsLimit: 1000000,
+        plan: "developer",
+      },
+      usage: {
+        api: 0,
+        archival: 0,
+        das: 50,
+        grpc: 0,
+        grpcGeyser: 0,
+        photon: 0,
+        rpc: 310,
+        stream: 0,
+        webhook: 20,
+        websocket: 0,
+      },
+    };
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => mockUsage,
+    });
+
+    const result = await admin.getProjectUsage("proj-123");
+
+    expect(result).toEqual(mockUsage);
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${ADMIN_API_URL}/admin/projects/proj-123/usage`,
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({
+          "X-Api-Key": "test-key",
+          "X-Helius-Client": "helius-sdk-tests/1.0.0",
+        }),
+      })
+    );
+  });
+});

--- a/src/admin/tests/getProjectUsage.test.ts
+++ b/src/admin/tests/getProjectUsage.test.ts
@@ -1,0 +1,71 @@
+import { createHeliusEager as createHelius } from "../../rpc/createHelius.eager";
+import { ADMIN_API_URL } from "../constants";
+import type { ProjectUsage } from "../types";
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch as jest.Mock;
+
+describe("getProjectUsage", () => {
+  let rpc: ReturnType<typeof createHelius>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    rpc = createHelius({ apiKey: "test-key" });
+  });
+
+  it("sends GET to the admin usage endpoint with X-Api-Key auth", async () => {
+    const mockUsage: ProjectUsage = {
+      creditsRemaining: 999080,
+      creditsUsed: 920,
+      prepaidCreditsRemaining: 5000,
+      prepaidCreditsUsed: 120,
+      subscriptionDetails: {
+        billingCycle: { start: "2026-04-01", end: "2026-05-01" },
+        creditsLimit: 1000000,
+        plan: "developer",
+      },
+      usage: {
+        api: 0,
+        archival: 0,
+        das: 50,
+        grpc: 0,
+        grpcGeyser: 0,
+        photon: 0,
+        rpc: 310,
+        stream: 0,
+        webhook: 20,
+        websocket: 0,
+      },
+    };
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => mockUsage,
+    });
+
+    const result = await rpc.admin.getProjectUsage("proj-123");
+
+    expect(result).toEqual(mockUsage);
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${ADMIN_API_URL}/admin/projects/proj-123/usage`,
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({
+          "X-Api-Key": "test-key",
+        }),
+      })
+    );
+  });
+
+  it("throws on HTTP error", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 403,
+      text: async () => "Admin API is not enabled for this project",
+    });
+
+    await expect(rpc.admin.getProjectUsage("proj-123")).rejects.toThrow(
+      "API error (403): Admin API is not enabled for this project"
+    );
+  });
+});

--- a/src/admin/tests/utils.test.ts
+++ b/src/admin/tests/utils.test.ts
@@ -1,0 +1,47 @@
+import { adminRequest } from "../utils";
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch as jest.Mock;
+
+describe("adminRequest", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("throws when options.headers X-Api-Key conflicts with apiKey argument", async () => {
+    await expect(
+      adminRequest("real-key", "/test", {
+        headers: { "X-Api-Key": "different-key" },
+      })
+    ).rejects.toThrow(
+      "X-Api-Key header in options.headers conflicts with the apiKey argument"
+    );
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("allows options.headers X-Api-Key when it matches apiKey argument", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ result: "ok" }),
+    });
+
+    const result = await adminRequest("real-key", "/test", {
+      headers: { "X-Api-Key": "real-key" },
+    });
+
+    expect(result).toEqual({ result: "ok" });
+    expect(mockFetch).toHaveBeenCalled();
+  });
+
+  it("allows requests with no X-Api-Key in options.headers", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ result: "ok" }),
+    });
+
+    const result = await adminRequest("real-key", "/test");
+
+    expect(result).toEqual({ result: "ok" });
+    expect(mockFetch).toHaveBeenCalled();
+  });
+});

--- a/src/admin/types.ts
+++ b/src/admin/types.ts
@@ -1,0 +1,32 @@
+export interface AdminBillingCycle {
+  start: string;
+  end: string;
+}
+
+export interface AdminUsageBreakdown {
+  api: number;
+  archival: number;
+  das: number;
+  grpc: number;
+  grpcGeyser: number;
+  photon: number;
+  rpc: number;
+  stream: number;
+  webhook: number;
+  websocket: number;
+}
+
+export interface AdminSubscriptionDetails {
+  billingCycle: AdminBillingCycle;
+  creditsLimit: number;
+  plan: string;
+}
+
+export interface ProjectUsage {
+  creditsRemaining: number;
+  creditsUsed: number;
+  prepaidCreditsRemaining: number;
+  prepaidCreditsUsed: number;
+  subscriptionDetails: AdminSubscriptionDetails;
+  usage: AdminUsageBreakdown;
+}

--- a/src/admin/utils.ts
+++ b/src/admin/utils.ts
@@ -1,12 +1,38 @@
 import { getSDKHeaders } from "../http";
 import { ADMIN_API_URL } from "./constants";
 
+function getHeaderValue(
+  headers: HeadersInit | undefined,
+  key: string
+): string | undefined {
+  if (!headers) return undefined;
+  if (headers instanceof Headers) return headers.get(key) ?? undefined;
+  if (Array.isArray(headers)) {
+    const entry = headers.find(
+      ([k]) => k.toLowerCase() === key.toLowerCase()
+    );
+    return entry ? entry[1] : undefined;
+  }
+  const found = Object.entries(headers).find(
+    ([k]) => k.toLowerCase() === key.toLowerCase()
+  );
+  return found ? found[1] : undefined;
+}
+
 export async function adminRequest<T>(
   apiKey: string,
   endpoint: string,
   options: RequestInit = {},
   userAgent?: string
 ): Promise<T> {
+  const headerApiKey = getHeaderValue(options.headers, "X-Api-Key");
+  if (headerApiKey !== undefined && headerApiKey !== apiKey) {
+    throw new Error(
+      "X-Api-Key header in options.headers conflicts with the apiKey argument. " +
+        "Remove the header or ensure it matches the apiKey passed to the client."
+    );
+  }
+
   const url = `${ADMIN_API_URL}${endpoint}`;
   const response = await fetch(url, {
     ...options,

--- a/src/admin/utils.ts
+++ b/src/admin/utils.ts
@@ -1,0 +1,27 @@
+import { getSDKHeaders } from "../http";
+import { ADMIN_API_URL } from "./constants";
+
+export async function adminRequest<T>(
+  apiKey: string,
+  endpoint: string,
+  options: RequestInit = {},
+  userAgent?: string
+): Promise<T> {
+  const url = `${ADMIN_API_URL}${endpoint}`;
+  const response = await fetch(url, {
+    ...options,
+    headers: {
+      ...getSDKHeaders(userAgent),
+      "Content-Type": "application/json",
+      "X-Api-Key": apiKey,
+      ...options.headers,
+    },
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`API error (${response.status}): ${errorText}`);
+  }
+
+  return response.json();
+}

--- a/src/rpc/createHelius.eager.ts
+++ b/src/rpc/createHelius.eager.ts
@@ -42,10 +42,7 @@ import {
   makeWalletClientEager,
   type WalletClient,
 } from "../wallet/client.eager";
-import {
-  makeAdminClientEager,
-  type AdminClient,
-} from "../admin/client.eager";
+import { makeAdminClientEager, type AdminClient } from "../admin/client.eager";
 import {
   GetAssetsByOwnerFn,
   makeGetAssetsByOwner,

--- a/src/rpc/createHelius.eager.ts
+++ b/src/rpc/createHelius.eager.ts
@@ -43,6 +43,10 @@ import {
   type WalletClient,
 } from "../wallet/client.eager";
 import {
+  makeAdminClientEager,
+  type AdminClient,
+} from "../admin/client.eager";
+import {
   GetAssetsByOwnerFn,
   makeGetAssetsByOwner,
 } from "./methods/getAssetsByOwner";
@@ -118,6 +122,8 @@ export interface HeliusClientEager {
   tx: TxHelpersEager;
 
   wallet: WalletClient;
+
+  admin: AdminClient;
 }
 
 export const createHeliusEager = ({
@@ -212,6 +218,16 @@ export const createHeliusEager = ({
         );
       }
       return makeWalletClientEager(apiKey, userAgent);
+    },
+
+    // Admin API
+    get admin() {
+      if (!apiKey) {
+        throw new Error(
+          "An API key is required to use the Admin API. Provide apiKey in createHelius() options."
+        );
+      }
+      return makeAdminClientEager(apiKey, userAgent);
     },
   };
 };

--- a/src/rpc/index.ts
+++ b/src/rpc/index.ts
@@ -41,6 +41,7 @@ import { makeWsAsync, WsAsync } from "../websockets/wsAsync";
 import { StakeClientLazy } from "../staking/client";
 import { ZkClientLazy } from "../zk/client";
 import type { WalletClient } from "../wallet/client";
+import type { AdminClient } from "../admin/client";
 import type { AuthClient } from "../auth/types";
 import type { HeliusRpcOptions } from "./types";
 
@@ -56,7 +57,7 @@ export type { HeliusRpcOptions };
  * directly on this object via a Proxy that delegates to the underlying
  * `@solana/kit` RPC client.
  *
- * Sub-clients (`webhooks`, `enhanced`, `tx`, `ws`, `stake`, `zk`, `wallet`)
+ * Sub-clients (`webhooks`, `enhanced`, `tx`, `ws`, `stake`, `zk`, `wallet`, `admin`)
  * are lazily loaded on first access to keep the initial bundle minimal.
  */
 export type HeliusClient = ResolvedHeliusRpcApi & {
@@ -143,6 +144,9 @@ export type HeliusClient = ResolvedHeliusRpcApi & {
 
   /** Wallet API client. Requires an API key. */
   wallet: WalletClient;
+
+  /** Admin API client. Requires an API key. */
+  admin: AdminClient;
 
   /** Auth client for agentic signup, checkout, and account management. */
   auth: AuthClient;
@@ -531,6 +535,16 @@ export const createHelius = ({
       return makeWalletClient(apiKey, userAgent);
     }
   );
+
+  defineLazyNamespace<HeliusClient, AdminClient>(client, "admin", async () => {
+    if (!apiKey) {
+      throw new Error(
+        "An API key is required to use the Admin API. Provide apiKey in createHelius() options."
+      );
+    }
+    const { makeAdminClient } = await import("../admin/client.js");
+    return makeAdminClient(apiKey, userAgent);
+  });
 
   defineLazyNamespace<HeliusClient, AuthClient>(client, "auth", async () => {
     const { makeAuthClient } = await import("../auth/client.js");

--- a/src/rpc/tests/createHelius.test.ts
+++ b/src/rpc/tests/createHelius.test.ts
@@ -132,6 +132,16 @@ describe("createHelius", () => {
     });
   });
 
+  describe("admin without apiKey", () => {
+    it("throws error when accessing admin methods without apiKey", async () => {
+      const rpc = createHelius({ baseUrl: "https://custom-rpc.example.com/" });
+
+      await expect(rpc.admin.getProjectUsage("proj-123")).rejects.toThrow(
+        "An API key is required to use the Admin API. Provide apiKey in createHelius() options."
+      );
+    });
+  });
+
   describe("backward compatibility", () => {
     it("works normally with apiKey provided", () => {
       const apiKey = "test-api-key";
@@ -242,6 +252,18 @@ describe("createHeliusEager", () => {
         })
       ).toThrow(
         "An API key is required to use webhooks/enhanced transactions. Provide apiKey in createHelius() options."
+      );
+    });
+  });
+
+  describe("admin without apiKey", () => {
+    it("throws error when accessing admin methods without apiKey", () => {
+      const rpc = createHeliusEager({
+        baseUrl: "https://custom-rpc.example.com/",
+      });
+
+      expect(() => rpc.admin.getProjectUsage("proj-123")).toThrow(
+        "An API key is required to use the Admin API. Provide apiKey in createHelius() options."
       );
     });
   });

--- a/src/rpc/types.ts
+++ b/src/rpc/types.ts
@@ -1,6 +1,6 @@
 /** Options for creating a Helius RPC client. */
 export interface HeliusRpcOptions {
-  /** Helius API key. Required for webhooks, enhanced transactions, and the Wallet API. */
+  /** Helius API key. Required for webhooks, enhanced transactions, the Wallet API, and the Admin API. */
   apiKey?: string;
   /** Solana network to connect to. Defaults to `"mainnet"`. */
   network?: "mainnet" | "devnet";


### PR DESCRIPTION
Adds initial Admin API support to `helius-sdk`

This PR introduces a new `helius.admin` namespace with `getProjectUsage(projectId)` for fetching project usage and billing-period credit data from the Admin API. It also adds a direct admin client export, typed response models, test coverage, and README/examples so the new endpoint is documented and easy to use.

Included:
- `helius.admin.getProjectUsage(projectId)`
- Direct admin client export
- Admin API types and request helpers
- Root client integration for lazy and eager clients
- README updates and example scripts
- Tests for request behavior, auth guards, and direct client usage

Verification:
- Focused Jest coverage for the new admin client and root client integration
- Full `npm run build` completed successfully
