### PR TITLE
refactor(auth): switch from OpenPay to Stripe price IDs

### DIFF
--- a/src/auth/agenticSignup.ts
+++ b/src/auth/agenticSignup.ts
@@ -6,10 +6,10 @@ import { walletSignup } from "./walletSignup";
 import { listProjects } from "./listProjects";
 import { getProject } from "./getProject";
 import { executeCheckout } from "./checkout";
-import { OPENPAY_PLANS } from "./constants";
-import { isOpenPayPlan, buildEndpoints } from "./signupHelpers";
+import { PAID_PLANS } from "./constants";
+import { isPaidPlan, buildEndpoints } from "./signupHelpers";
 
-const ALL_PLANS = ["basic", ...OPENPAY_PLANS];
+const ALL_PLANS = ["basic", ...PAID_PLANS];
 
 export async function agenticSignup(
   options: AgenticSignupOptions
@@ -21,7 +21,7 @@ export async function agenticSignup(
   const plan = rawPlan === "" ? "basic" : rawPlan.toLowerCase();
 
   // Validate plan
-  if (plan !== "basic" && !isOpenPayPlan(plan)) {
+  if (plan !== "basic" && !isPaidPlan(plan)) {
     throw new Error(
       `Unknown plan: ${plan}. Available: ${ALL_PLANS.join(", ")}`
     );
@@ -44,8 +44,8 @@ export async function agenticSignup(
     const projectDetails = await getProject(jwt, project.id, userAgent);
     const apiKey = projectDetails.apiKeys?.[0]?.keyId || null;
 
-    // Existing user + OpenPay plan → upgrade
-    if (isOpenPayPlan(plan)) {
+    // Existing user + paid plan → upgrade
+    if (isPaidPlan(plan)) {
       // All-or-none customer info validation
       const hasAny = email || firstName || lastName;
       if (hasAny && (!email || !firstName || !lastName)) {
@@ -107,7 +107,7 @@ export async function agenticSignup(
 
   // ── New user paths ── All plans go through checkout
 
-  if (isOpenPayPlan(plan)) {
+  if (isPaidPlan(plan)) {
     // Validate required contact info for new subscriptions
     if (!email || !firstName || !lastName) {
       const missing = [

--- a/src/auth/checkout.ts
+++ b/src/auth/checkout.ts
@@ -16,7 +16,7 @@ import {
   PROJECT_POLL_TIMEOUT_MS,
   PLAN_TO_USAGE_PLAN,
 } from "./constants";
-import { fetchOpenPayPriceIds } from "./devPortalConfigs";
+import { fetchStripePriceIds } from "./devPortalConfigs";
 import { payPaymentIntent } from "./payPaymentIntent";
 
 export async function resolvePriceId(
@@ -31,7 +31,7 @@ export async function resolvePriceId(
       `Unknown plan: ${plan}. Available: ${Object.keys(PLAN_TO_USAGE_PLAN).join(", ")}`
     );
   }
-  const priceIds = await fetchOpenPayPriceIds(jwt, userAgent);
+  const priceIds = await fetchStripePriceIds(jwt, userAgent);
   const periodKey = period === "monthly" ? "Monthly" : "Yearly";
   const priceId = priceIds[periodKey]?.[usagePlan];
   if (!priceId) {
@@ -265,7 +265,7 @@ export async function executeCheckout(
   return result;
 }
 
-/** Execute a plan upgrade via OpenPay checkout.
+/** Execute a plan upgrade via checkout.
  * @param customerInfo - Optional contact info (email, firstName, lastName); if any field is given, all three should be present. */
 export async function executeUpgrade(
   secretKey: Uint8Array,

--- a/src/auth/constants.ts
+++ b/src/auth/constants.ts
@@ -16,7 +16,7 @@ export const USDC_MINT = USDC_MINT_MAINNET;
 /** Legacy: 1 USDC (6 decimals). Only used by payUSDC. */
 export const PAYMENT_AMOUNT = 1_000_000n;
 
-/** Maps plan catalog keys to the keys returned by /dev-portal/configs openPay.priceIds */
+/** Maps plan catalog keys to the keys returned by /dev-portal/configs stripe.priceIds */
 export const PLAN_TO_USAGE_PLAN: Record<string, string> = {
   basic: "basic",
   developer: "developer_v4",
@@ -30,10 +30,15 @@ export const MIN_SOL_FOR_TX = 1_000_000n;
 export const MEMO_PROGRAM_ID =
   "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr" as Address;
 
-// ── OpenPay Plan Names (single source of truth) ──
+// ── Paid plan names (single source of truth) ──
 
-export const OPENPAY_PLANS = ["developer", "business", "professional"] as const;
-export type OpenPayPlan = (typeof OPENPAY_PLANS)[number];
+export const PAID_PLANS = ["developer", "business", "professional"] as const;
+export type PaidPlan = (typeof PAID_PLANS)[number];
+
+/** @deprecated Use PAID_PLANS instead */
+export const OPENPAY_PLANS = PAID_PLANS;
+/** @deprecated Use PaidPlan instead */
+export type OpenPayPlan = PaidPlan;
 
 export const CHECKOUT_POLL_INTERVAL_MS = 1_000;
 export const CHECKOUT_POLL_TIMEOUT_MS = 60_000;

--- a/src/auth/devPortalConfigs.ts
+++ b/src/auth/devPortalConfigs.ts
@@ -1,7 +1,14 @@
 import { authRequest } from "./utils";
 
 interface DevPortalConfigsResponse {
-  openPay: {
+  stripe: {
+    priceIds: {
+      Monthly: Record<string, string>;
+      Yearly: Record<string, string>;
+    };
+  };
+  // Keep openPay as optional for backwards compat during transition
+  openPay?: {
     priceIds: {
       Monthly: Record<string, string>;
       Yearly: Record<string, string>;
@@ -9,7 +16,7 @@ interface DevPortalConfigsResponse {
   };
 }
 
-export async function fetchOpenPayPriceIds(
+export async function fetchStripePriceIds(
   jwt: string,
   userAgent?: string
 ): Promise<{
@@ -24,5 +31,8 @@ export async function fetchOpenPayPriceIds(
     },
     userAgent
   );
-  return configs.openPay.priceIds;
+  return configs.stripe.priceIds;
 }
+
+/** @deprecated Use fetchStripePriceIds instead */
+export const fetchOpenPayPriceIds = fetchStripePriceIds;

--- a/src/auth/signupHelpers.ts
+++ b/src/auth/signupHelpers.ts
@@ -1,8 +1,11 @@
-import { OPENPAY_PLANS } from "./constants";
+import { PAID_PLANS } from "./constants";
 
-export function isOpenPayPlan(plan: string): boolean {
-  return (OPENPAY_PLANS as readonly string[]).includes(plan);
+export function isPaidPlan(plan: string): boolean {
+  return (PAID_PLANS as readonly string[]).includes(plan);
 }
+
+/** @deprecated Use isPaidPlan instead */
+export const isOpenPayPlan = isPaidPlan;
 
 export function buildEndpoints(apiKey: string) {
   return {

--- a/src/auth/tests/agenticSignup.test.ts
+++ b/src/auth/tests/agenticSignup.test.ts
@@ -177,9 +177,9 @@ describe("agenticSignup", () => {
     });
   });
 
-  // ── OpenPay signup (new user) ──
+  // ── Paid plan signup (new user) ──
 
-  describe("OpenPay signup (new user)", () => {
+  describe("Paid plan signup (new user)", () => {
     const CONTACT = {
       email: "user@example.com",
       firstName: "Test",

--- a/src/auth/tests/checkout.test.ts
+++ b/src/auth/tests/checkout.test.ts
@@ -15,7 +15,7 @@ import { listProjects } from "../listProjects";
 import { getProject } from "../getProject";
 import { loadKeypair } from "../loadKeypair";
 import { getAddress } from "../getAddress";
-import { fetchOpenPayPriceIds } from "../devPortalConfigs";
+import { fetchStripePriceIds } from "../devPortalConfigs";
 import { paySponsoredIntent } from "../sponsoredPayment";
 
 jest.mock("../utils");
@@ -51,8 +51,8 @@ const mockListProjects = listProjects as jest.MockedFunction<
 const mockGetProject = getProject as jest.MockedFunction<typeof getProject>;
 const mockLoadKeypair = loadKeypair as jest.MockedFunction<typeof loadKeypair>;
 const mockGetAddress = getAddress as jest.MockedFunction<typeof getAddress>;
-const mockFetchOpenPayPriceIds = fetchOpenPayPriceIds as jest.MockedFunction<
-  typeof fetchOpenPayPriceIds
+const mockFetchStripePriceIds = fetchStripePriceIds as jest.MockedFunction<
+  typeof fetchStripePriceIds
 >;
 const mockPaySponsoredIntent = paySponsoredIntent as jest.MockedFunction<
   typeof paySponsoredIntent
@@ -97,25 +97,25 @@ describe("resolvePriceId", () => {
   beforeEach(() => jest.resetAllMocks());
 
   it("resolves basic monthly", async () => {
-    mockFetchOpenPayPriceIds.mockResolvedValue(MOCK_PRICE_IDS);
+    mockFetchStripePriceIds.mockResolvedValue(MOCK_PRICE_IDS);
     const result = await resolvePriceId("jwt", "basic", "monthly");
     expect(result).toBe("price_basic_monthly");
   });
 
   it("resolves developer monthly", async () => {
-    mockFetchOpenPayPriceIds.mockResolvedValue(MOCK_PRICE_IDS);
+    mockFetchStripePriceIds.mockResolvedValue(MOCK_PRICE_IDS);
     const result = await resolvePriceId("jwt", "developer", "monthly");
     expect(result).toBe("price_dev_monthly");
   });
 
   it("resolves business yearly", async () => {
-    mockFetchOpenPayPriceIds.mockResolvedValue(MOCK_PRICE_IDS);
+    mockFetchStripePriceIds.mockResolvedValue(MOCK_PRICE_IDS);
     const result = await resolvePriceId("jwt", "business", "yearly");
     expect(result).toBe("price_biz_yearly");
   });
 
   it("is case-insensitive for plan name", async () => {
-    mockFetchOpenPayPriceIds.mockResolvedValue(MOCK_PRICE_IDS);
+    mockFetchStripePriceIds.mockResolvedValue(MOCK_PRICE_IDS);
     const result = await resolvePriceId("jwt", "Developer", "monthly");
     expect(result).toBe("price_dev_monthly");
   });
@@ -133,7 +133,7 @@ describe("resolvePriceId", () => {
   });
 
   it("throws when priceId not found in configs (empty)", async () => {
-    mockFetchOpenPayPriceIds.mockResolvedValue({
+    mockFetchStripePriceIds.mockResolvedValue({
       Monthly: {},
       Yearly: {},
     });
@@ -143,7 +143,7 @@ describe("resolvePriceId", () => {
   });
 
   it("throws with available keys when key mismatch", async () => {
-    mockFetchOpenPayPriceIds.mockResolvedValue({
+    mockFetchStripePriceIds.mockResolvedValue({
       Monthly: { some_other_plan: "price_unknown" },
       Yearly: {},
     });
@@ -295,7 +295,7 @@ describe("executeCheckout", () => {
   const mockSecretKey = new Uint8Array(64).fill(1);
 
   function setupDefaultMocks() {
-    mockFetchOpenPayPriceIds.mockResolvedValue(MOCK_PRICE_IDS);
+    mockFetchStripePriceIds.mockResolvedValue(MOCK_PRICE_IDS);
     mockLoadKeypair.mockReturnValue({
       publicKey: new Uint8Array(32),
       secretKey: mockSecretKey,
@@ -476,7 +476,7 @@ describe("executeCheckout", () => {
 describe("getCheckoutPreview", () => {
   beforeEach(() => {
     jest.resetAllMocks();
-    mockFetchOpenPayPriceIds.mockResolvedValue(MOCK_PRICE_IDS);
+    mockFetchStripePriceIds.mockResolvedValue(MOCK_PRICE_IDS);
   });
 
   it("resolves priceId and sends GET to /checkout/preview with query params", async () => {
@@ -561,7 +561,7 @@ describe("getPaymentStatus", () => {
 describe("getSignupQuote", () => {
   beforeEach(() => {
     jest.resetAllMocks();
-    mockFetchOpenPayPriceIds.mockResolvedValue(MOCK_PRICE_IDS);
+    mockFetchStripePriceIds.mockResolvedValue(MOCK_PRICE_IDS);
   });
 
   it("returns simplified quote from checkout preview", async () => {
@@ -601,7 +601,7 @@ describe("getSignupQuote", () => {
 describe("initializeSignupFunding", () => {
   beforeEach(() => {
     jest.resetAllMocks();
-    mockFetchOpenPayPriceIds.mockResolvedValue(MOCK_PRICE_IDS);
+    mockFetchStripePriceIds.mockResolvedValue(MOCK_PRICE_IDS);
   });
 
   it("resolves priceId and returns funding intent with sponsored mode", async () => {

--- a/src/auth/tests/checkoutPreview.test.ts
+++ b/src/auth/tests/checkoutPreview.test.ts
@@ -1,13 +1,13 @@
 import { getCheckoutPreview } from "../checkout";
 import { authRequest } from "../utils";
-import { fetchOpenPayPriceIds } from "../devPortalConfigs";
+import { fetchStripePriceIds } from "../devPortalConfigs";
 
 jest.mock("../utils");
 jest.mock("../devPortalConfigs");
 
 const mockAuthRequest = authRequest as jest.MockedFunction<typeof authRequest>;
-const mockFetchOpenPayPriceIds = fetchOpenPayPriceIds as jest.MockedFunction<
-  typeof fetchOpenPayPriceIds
+const mockFetchStripePriceIds = fetchStripePriceIds as jest.MockedFunction<
+  typeof fetchStripePriceIds
 >;
 
 const MOCK_PRICE_IDS = {
@@ -26,7 +26,7 @@ const MOCK_PRICE_IDS = {
 describe("getCheckoutPreview", () => {
   beforeEach(() => {
     jest.resetAllMocks();
-    mockFetchOpenPayPriceIds.mockResolvedValue(MOCK_PRICE_IDS);
+    mockFetchStripePriceIds.mockResolvedValue(MOCK_PRICE_IDS);
   });
 
   it("fetches preview with all params", async () => {

--- a/src/auth/tests/deprecatedAliases.test.ts
+++ b/src/auth/tests/deprecatedAliases.test.ts
@@ -1,0 +1,35 @@
+import {
+  fetchOpenPayPriceIds,
+  fetchStripePriceIds,
+} from "../devPortalConfigs";
+import {
+  OPENPAY_PLANS,
+  PAID_PLANS,
+  type OpenPayPlan,
+  type PaidPlan,
+} from "../constants";
+import { isOpenPayPlan, isPaidPlan } from "../signupHelpers";
+
+describe("deprecated auth aliases", () => {
+  it("keeps fetchOpenPayPriceIds as an alias of fetchStripePriceIds", () => {
+    expect(fetchOpenPayPriceIds).toBe(fetchStripePriceIds);
+  });
+
+  it("keeps OPENPAY_PLANS as an alias of PAID_PLANS", () => {
+    expect(OPENPAY_PLANS).toBe(PAID_PLANS);
+    expect(OPENPAY_PLANS).toEqual(["developer", "business", "professional"]);
+  });
+
+  it("keeps isOpenPayPlan as an alias of isPaidPlan", () => {
+    expect(isOpenPayPlan).toBe(isPaidPlan);
+    expect(isOpenPayPlan("developer")).toBe(true);
+    expect(isOpenPayPlan("basic")).toBe(false);
+  });
+
+  it("keeps the legacy plan type alias assignable", () => {
+    const legacyPlan: OpenPayPlan = "developer";
+    const paidPlan: PaidPlan = legacyPlan;
+
+    expect(paidPlan).toBe("developer");
+  });
+});

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -121,7 +121,7 @@ export interface CheckoutRequest {
 }
 
 export interface CheckoutInitializeRequest {
-  priceId: string; // OpenPay price ID — resolved internally from plan+period
+  priceId: string; // Price ID — resolved internally from plan+period
   refId: string; // User ID (base58 from walletSignup) or project UUID
   email?: string;
   firstName?: string;
@@ -204,11 +204,11 @@ export interface AgenticSignupOptions {
   secretKey: Uint8Array;
   userAgent?: string;
   plan?: string; // 'basic' ($1, default) | 'developer' | 'business' | 'professional'
-  period?: "monthly" | "yearly"; // Only for OpenPay plans, default 'monthly'
-  email?: string; // Only for OpenPay plans
-  firstName?: string; // Only for OpenPay plans
-  lastName?: string; // Only for OpenPay plans
-  couponCode?: string; // Only for OpenPay plans
+  period?: "monthly" | "yearly"; // Only for paid plans, default 'monthly'
+  email?: string; // Only for paid plans
+  firstName?: string; // Only for paid plans
+  lastName?: string; // Only for paid plans
+  couponCode?: string; // Only for paid plans
 }
 
 export interface AgenticSignupResult {


### PR DESCRIPTION
OpenPay is deprecated. This updates the SDK to read `stripe.priceIds` from `/dev-portal/configs` instead of `openPay.priceIds`. Backwards-compatible deprecated aliases are kept for all renamed exports.

Slack thread: https://helius-labs.slack.com/archives/C03TJTY5UEQ/p1776346881652139