### PR TITLE
feat(auth): Agent Plan signup + prepaid-credits top-up; migrate to stripe.priceIds

### DIFF
--- a/bundlemon.config.js
+++ b/bundlemon.config.js
@@ -20,6 +20,15 @@ export default {
       maxSize: '1.5kb',
     },
     {
+      // Opt out of the default 15% growth ratchet: this module exposes a
+      // small family of configs-fetch helpers (fetchDevPortalConfigs,
+      // fetchStripePriceIds, fetchPrepaidCreditsPriceIds, and the
+      // deprecated fetchOpenPayPriceIds wrapper). The absolute cap still
+      // gates unbounded growth.
+      path: 'dist/esm/auth/devPortalConfigs.js',
+      maxSize: '2.5kb',
+    },
+    {
       path: 'dist/esm/rpc/index.js',
       maxSize: '2.52kb',
     },

--- a/examples/auth/agenticSignupAgent.ts
+++ b/examples/auth/agenticSignupAgent.ts
@@ -1,0 +1,38 @@
+import { makeAuthClient } from "helius-sdk/auth/client";
+import { createHelius } from "helius-sdk";
+
+/**
+ * Sign up for the Agent Plan.
+ *
+ * Agent is a one-time 10 USDC purchase that provisions 1,000,000 starting
+ * credits. Contact info (email, firstName, lastName) is required for
+ * new-user signups on any paid plan. SOL fees are sponsored — the user's
+ * keypair only needs USDC.
+ */
+(async () => {
+  const auth = makeAuthClient("helius-sdk-example/agent");
+
+  const { secretKey } = await auth.generateKeypair();
+
+  const result = await auth.agenticSignup({
+    secretKey,
+    plan: "agent",
+    email: "agent@example.com",
+    firstName: "Agent",
+    lastName: "User",
+    // period is ignored for the agent plan (one-time invoice).
+  });
+
+  console.log("Status:", result.status); // "success" (new) or "upgraded"
+  console.log("Wallet:", result.walletAddress);
+  console.log("Project ID:", result.projectId);
+  console.log("API Key:", result.apiKey);
+  console.log("Payment TX:", result.txSignature);
+
+  if (result.apiKey) {
+    // Agent plan ships with 1,000,000 credits — the API is usable immediately.
+    const helius = createHelius({ apiKey: result.apiKey });
+    const slot = await helius.getSlot();
+    console.log("Current slot:", slot);
+  }
+})();

--- a/examples/auth/purchaseCredits.ts
+++ b/examples/auth/purchaseCredits.ts
@@ -1,0 +1,42 @@
+import { makeAuthClient } from "helius-sdk/auth/client";
+
+/**
+ * Buy additional prepaid credits for an agent-plan project.
+ *
+ * Agent-only in this release. Each unit of `qty` grants 1,000,000 credits
+ * at the backend. 10 USDC × qty=1 → 1M credits; 10 × 3 → 3M credits.
+ * SOL fees are sponsored.
+ */
+(async () => {
+  const auth = makeAuthClient("helius-sdk-example/credits");
+
+  // Load the same keypair used for signup (paste your saved bytes).
+  const secretKey = new Uint8Array(
+    /* paste 64-byte secretKey array here */
+  );
+  const keypair = auth.loadKeypair(secretKey);
+  const walletAddress = await auth.getAddress(keypair);
+
+  // Authenticate the wallet to get a JWT.
+  const { message, signature } = await auth.signAuthMessage(secretKey);
+  const { token: jwt } = await auth.walletSignup(
+    message,
+    signature,
+    walletAddress
+  );
+
+  // Use the existing agent-plan project (first project on the account).
+  const projects = await auth.listProjects(jwt);
+  const projectId = projects[0]?.id;
+  if (!projectId) throw new Error("No project found — sign up first.");
+
+  const result = await auth.purchaseCredits(secretKey, jwt, {
+    tier: "10_USDC", // default; omit to use the default
+    qty: 1,
+    projectId,
+  });
+
+  console.log("Status:", result.status);
+  console.log("TX:", result.txSignature);
+  console.log("Amount (cents):", result.amountCents);
+})();

--- a/src/auth/agenticSignup.ts
+++ b/src/auth/agenticSignup.ts
@@ -11,6 +11,17 @@ import { isAgentPlan, isOpenPayPlan, buildEndpoints } from "./signupHelpers";
 
 const ALL_PLANS = [...OPENPAY_PLANS, ...AGENT_PLANS];
 
+/**
+ * Sign up or upgrade an account on the agent / OpenPay plans.
+ *
+ * Sponsorship asymmetry: new-account checkouts run in `paymentMode:
+ * "sponsored"` so Helius covers the on-chain payment. Existing-user
+ * upgrades — including agent-plan upgrades — are *not* sponsored: the
+ * backend rejects sponsored mode on the upgrade path, so this SDK falls
+ * back to a self-funded checkout for the second signup of the same
+ * wallet. If you need a sponsored agent setup, sign up with a fresh
+ * wallet rather than upgrading an existing project.
+ */
 export async function agenticSignup(
   options: AgenticSignupOptions
 ): Promise<AgenticSignupResult> {

--- a/src/auth/agenticSignup.ts
+++ b/src/auth/agenticSignup.ts
@@ -11,17 +11,9 @@ import { isAgentPlan, isOpenPayPlan, buildEndpoints } from "./signupHelpers";
 
 const ALL_PLANS = [...OPENPAY_PLANS, ...AGENT_PLANS];
 
-/**
- * Sign up or upgrade an account on the agent / OpenPay plans.
- *
- * Sponsorship asymmetry: new-account checkouts run in `paymentMode:
- * "sponsored"` so Helius covers the on-chain payment. Existing-user
- * upgrades — including agent-plan upgrades — are *not* sponsored: the
- * backend rejects sponsored mode on the upgrade path, so this SDK falls
- * back to a self-funded checkout for the second signup of the same
- * wallet. If you need a sponsored agent setup, sign up with a fresh
- * wallet rather than upgrading an existing project.
- */
+// New-account checkouts are sponsored; upgrades are not (backend rejects
+// sponsored mode on the upgrade path). To get a sponsored agent setup,
+// sign up from a fresh wallet rather than upgrading an existing project.
 export async function agenticSignup(
   options: AgenticSignupOptions
 ): Promise<AgenticSignupResult> {

--- a/src/auth/agenticSignup.ts
+++ b/src/auth/agenticSignup.ts
@@ -6,35 +6,53 @@ import { walletSignup } from "./walletSignup";
 import { listProjects } from "./listProjects";
 import { getProject } from "./getProject";
 import { executeCheckout } from "./checkout";
-import { OPENPAY_PLANS } from "./constants";
-import { isOpenPayPlan, buildEndpoints } from "./signupHelpers";
+import { AGENT_PLANS, OPENPAY_PLANS } from "./constants";
+import { isAgentPlan, isOpenPayPlan, buildEndpoints } from "./signupHelpers";
 
-const ALL_PLANS = ["basic", ...OPENPAY_PLANS];
+const ALL_PLANS = [...OPENPAY_PLANS, ...AGENT_PLANS];
 
 export async function agenticSignup(
   options: AgenticSignupOptions
 ): Promise<AgenticSignupResult> {
   const { secretKey, userAgent, email, firstName, lastName } = options;
 
-  // Normalize plan: undefined/empty → "basic"
+  // Normalize plan: undefined/empty → "agent" (new default entry plan).
   const rawPlan = options.plan?.trim() || "";
-  const plan = rawPlan === "" ? "basic" : rawPlan.toLowerCase();
+  const plan = rawPlan === "" ? "agent" : rawPlan.toLowerCase();
 
   // Validate plan
-  if (plan !== "basic" && !isOpenPayPlan(plan)) {
+  if (!isOpenPayPlan(plan) && !isAgentPlan(plan)) {
     throw new Error(
       `Unknown plan: ${plan}. Available: ${ALL_PLANS.join(", ")}`
     );
   }
 
-  // Load keypair and derive address
+  // Pre-authenticated session reuse: if the caller already ran walletSignup
+  // (e.g. to fetch a pricing quote), let them pass jwt + refId to skip the
+  // internal re-auth round trip.
   const keypair = loadKeypair(secretKey);
   const walletAddress = await getAddress(keypair);
 
-  // Authenticate
-  const { message, signature } = await signAuthMessage(secretKey);
-  const auth = await walletSignup(message, signature, walletAddress, userAgent);
-  const jwt = auth.token;
+  let jwt: string;
+  let refId: string;
+  if (options.jwt && options.refId) {
+    jwt = options.jwt;
+    refId = options.refId;
+  } else if (options.jwt || options.refId) {
+    throw new Error(
+      "agenticSignup: pass both `jwt` and `refId` together, or neither."
+    );
+  } else {
+    const { message, signature } = await signAuthMessage(secretKey);
+    const auth = await walletSignup(
+      message,
+      signature,
+      walletAddress,
+      userAgent
+    );
+    jwt = auth.token;
+    refId = auth.refId;
+  }
 
   // Check for existing projects
   const existingProjects = await listProjects(jwt, userAgent);
@@ -44,93 +62,76 @@ export async function agenticSignup(
     const projectDetails = await getProject(jwt, project.id, userAgent);
     const apiKey = projectDetails.apiKeys?.[0]?.keyId || null;
 
-    // Existing user + OpenPay plan → upgrade
-    if (isOpenPayPlan(plan)) {
-      // All-or-none customer info validation
-      const hasAny = email || firstName || lastName;
-      if (hasAny && (!email || !firstName || !lastName)) {
-        const missing = [
-          !email && "email",
-          !firstName && "firstName",
-          !lastName && "lastName",
-        ].filter(Boolean);
-        throw new Error(
-          `Partial customer info provided. If any of email/firstName/lastName is given, all three are required. Missing: ${missing.join(", ")}`
-        );
-      }
-
-      const upgradeResult = await executeCheckout(
-        secretKey,
-        jwt,
-        {
-          plan,
-          period: options.period ?? "monthly",
-          refId: project.id,
-          couponCode: options.couponCode,
-          email,
-          firstName,
-          lastName,
-        },
-        userAgent,
-        { skipProjectPolling: true }
-      );
-
-      if (upgradeResult.status !== "completed") {
-        throw new Error(
-          `Checkout ${upgradeResult.status}${upgradeResult.error ? `: ${upgradeResult.error}` : ""}${upgradeResult.txSignature ? `. TX: ${upgradeResult.txSignature}` : ""}`
-        );
-      }
-
-      return {
-        status: "upgraded",
-        jwt,
-        walletAddress,
-        projectId: project.id,
-        apiKey,
-        endpoints: apiKey ? buildEndpoints(apiKey) : null,
-        credits: null,
-        txSignature: upgradeResult.txSignature ?? undefined,
-      };
-    }
-
-    // Existing user + basic plan → return existing project
-    return {
-      status: "existing_project",
-      jwt,
-      walletAddress,
-      projectId: project.id,
-      apiKey,
-      endpoints: apiKey ? buildEndpoints(apiKey) : null,
-      credits: projectDetails.creditsUsage?.remainingCredits ?? null,
-    };
-  }
-
-  // ── New user paths ── All plans go through checkout
-
-  if (isOpenPayPlan(plan)) {
-    // Validate required contact info for new subscriptions
-    if (!email || !firstName || !lastName) {
+    // All-or-none customer info validation
+    const hasAny = email || firstName || lastName;
+    if (hasAny && (!email || !firstName || !lastName)) {
       const missing = [
         !email && "email",
         !firstName && "firstName",
         !lastName && "lastName",
       ].filter(Boolean);
       throw new Error(
-        `Paid plans require contact info for new accounts. Missing: ${missing.join(", ")}. ` +
-          `Pass --email, --first-name, and --last-name.`
+        `Partial customer info provided. If any of email/firstName/lastName is given, all three are required. Missing: ${missing.join(", ")}`
       );
     }
+
+    const upgradeResult = await executeCheckout(
+      secretKey,
+      jwt,
+      {
+        plan,
+        period: options.period ?? "monthly",
+        refId: project.id,
+        couponCode: options.couponCode,
+        email,
+        firstName,
+        lastName,
+      },
+      userAgent,
+      { skipProjectPolling: true }
+    );
+
+    if (upgradeResult.status !== "completed") {
+      throw new Error(
+        `Checkout ${upgradeResult.status}${upgradeResult.error ? `: ${upgradeResult.error}` : ""}${upgradeResult.txSignature ? `. TX: ${upgradeResult.txSignature}` : ""}`
+      );
+    }
+
+    return {
+      status: "upgraded",
+      jwt,
+      walletAddress,
+      projectId: project.id,
+      apiKey,
+      endpoints: apiKey ? buildEndpoints(apiKey) : null,
+      credits: null,
+      txSignature: upgradeResult.txSignature ?? undefined,
+    };
   }
 
-  // Checkout for all plans (basic, developer, business, professional)
-  // Always use sponsored mode — payPaymentIntent falls back to self-funded if needed
+  // ── New user path ── All supported plans go through sponsored checkout
+
+  if (!email || !firstName || !lastName) {
+    const missing = [
+      !email && "email",
+      !firstName && "firstName",
+      !lastName && "lastName",
+    ].filter(Boolean);
+    throw new Error(
+      `Paid plans require contact info for new accounts. Missing: ${missing.join(", ")}. ` +
+        `Pass --email, --first-name, and --last-name.`
+    );
+  }
+
+  // Checkout for all plans (developer, business, professional, agent).
+  // Always use sponsored mode — payPaymentIntent falls back to self-funded if needed.
   const checkoutResult = await executeCheckout(
     secretKey,
     jwt,
     {
       plan,
       period: options.period ?? "monthly",
-      refId: auth.refId,
+      refId,
       email,
       firstName,
       lastName,

--- a/src/auth/checkout.ts
+++ b/src/auth/checkout.ts
@@ -16,7 +16,7 @@ import {
   PROJECT_POLL_TIMEOUT_MS,
   PLAN_TO_USAGE_PLAN,
 } from "./constants";
-import { fetchOpenPayPriceIds } from "./devPortalConfigs";
+import { fetchStripePriceIds } from "./devPortalConfigs";
 import { payPaymentIntent } from "./payPaymentIntent";
 
 export async function resolvePriceId(
@@ -25,13 +25,35 @@ export async function resolvePriceId(
   period: "monthly" | "yearly",
   userAgent?: string
 ): Promise<string> {
-  const usagePlan = PLAN_TO_USAGE_PLAN[plan.toLowerCase()];
+  const planKey = plan.toLowerCase();
+  const usagePlan = PLAN_TO_USAGE_PLAN[planKey];
   if (!usagePlan) {
     throw new Error(
       `Unknown plan: ${plan}. Available: ${Object.keys(PLAN_TO_USAGE_PLAN).join(", ")}`
     );
   }
-  const priceIds = await fetchOpenPayPriceIds(jwt, userAgent);
+
+  // Agent plan lives at a flat path (stripe.priceIds.AgentPlan) and is
+  // only returned when the backend sees ?agent=cli. It has no period
+  // concept (one-time invoice), so `period` is ignored here.
+  if (planKey === "agent") {
+    const priceIds = await fetchStripePriceIds(
+      jwt,
+      { includeAgentPlan: true },
+      userAgent
+    );
+    const priceId = priceIds.AgentPlan;
+    if (!priceId) {
+      throw new Error(
+        `No priceId found for plan "agent". The backend did not return ` +
+          `stripe.priceIds.AgentPlan — likely the PRICE_ID_AGENT_PLAN ` +
+          `secret is not configured in this environment.`
+      );
+    }
+    return priceId;
+  }
+
+  const priceIds = await fetchStripePriceIds(jwt, undefined, userAgent);
   const periodKey = period === "monthly" ? "Monthly" : "Yearly";
   const priceId = priceIds[periodKey]?.[usagePlan];
   if (!priceId) {

--- a/src/auth/client.ts
+++ b/src/auth/client.ts
@@ -23,6 +23,7 @@ import {
 } from "./checkout";
 import { getSignupQuote, initializeSignupFunding } from "./signupFunding";
 import { agenticSignup } from "./agenticSignup";
+import { purchaseCredits } from "./purchaseCredits";
 
 export function makeAuthClient(userAgent?: string): AuthClient {
   return {
@@ -74,5 +75,7 @@ export function makeAuthClient(userAgent?: string): AuthClient {
         customerInfo
       ),
     executeRenewal: (sk, jwt, id) => executeRenewal(sk, jwt, id, userAgent),
+    purchaseCredits: (sk, jwt, options) =>
+      purchaseCredits(sk, jwt, options, userAgent),
   };
 }

--- a/src/auth/constants.ts
+++ b/src/auth/constants.ts
@@ -16,12 +16,22 @@ export const USDC_MINT = USDC_MINT_MAINNET;
 /** Legacy: 1 USDC (6 decimals). Only used by payUSDC. */
 export const PAYMENT_AMOUNT = 1_000_000n;
 
-/** Maps plan catalog keys to the keys returned by /dev-portal/configs openPay.priceIds */
+/**
+ * Maps plan catalog keys to backend price lookup keys.
+ *
+ * For developer/business/professional, the value is the key under
+ * `stripe.priceIds.Monthly` / `Yearly` returned by `/dev-portal/configs`.
+ *
+ * For agent, the value is the backend `UsagePlan` enum (`agent_v4`) but
+ * the priceId itself lives at the flat path `stripe.priceIds.AgentPlan`
+ * and is only returned when the request includes `?agent=cli`.
+ * `resolvePriceId` branches on plan name to handle this.
+ */
 export const PLAN_TO_USAGE_PLAN: Record<string, string> = {
-  basic: "basic",
   developer: "developer_v4",
   business: "business_v4",
   professional: "professional_v4",
+  agent: "agent_v4",
 };
 
 /** Minimum SOL needed for transaction fees (~0.001 SOL) */
@@ -34,6 +44,15 @@ export const MEMO_PROGRAM_ID =
 
 export const OPENPAY_PLANS = ["developer", "business", "professional"] as const;
 export type OpenPayPlan = (typeof OPENPAY_PLANS)[number];
+
+/**
+ * The Agent Plan is a one-time 10 USDC purchase that ships with 1,000,000
+ * starting credits. Different billing semantics from the OpenPay-family
+ * plans (no Monthly/Yearly period, one-time Stripe invoice, Stripe-only
+ * provider), so it lives in its own set.
+ */
+export const AGENT_PLANS = ["agent"] as const;
+export type AgentPlan = (typeof AGENT_PLANS)[number];
 
 export const CHECKOUT_POLL_INTERVAL_MS = 1_000;
 export const CHECKOUT_POLL_TIMEOUT_MS = 60_000;

--- a/src/auth/devPortalConfigs.ts
+++ b/src/auth/devPortalConfigs.ts
@@ -1,7 +1,30 @@
 import { authRequest } from "./utils";
 
-interface DevPortalConfigsResponse {
-  openPay: {
+/**
+ * Response shape of `GET /dev-portal/configs`, mirroring the monorepo's
+ * `DevPortalConfigsResponse` (`ts-services/dev-api-lambda/model/pricing-products.ts`).
+ *
+ * Only the fields the SDK actively reads are strongly typed; other sections
+ * (sphere, loop, openPay) still appear in the live response but are
+ * vestigial after the backend's OpenPay → Stripe migration. The SDK should
+ * always read plan pricing from `stripe.priceIds`.
+ */
+export interface DevPortalConfigsResponse {
+  stripe: {
+    priceIds: {
+      Monthly: Record<string, string>;
+      Yearly: Record<string, string>;
+      /** Present only when the request was made with `?agent=cli`. */
+      AgentPlan?: string;
+    };
+    prepaidCreditsPlans?: Record<string, string>;
+  };
+  /**
+   * Deprecated. The backend still returns this section for transitional
+   * compatibility but the OpenPay billing handler has been deleted and
+   * `openpay.service.ts` is stubbed. Prefer `stripe.priceIds`.
+   */
+  openPay?: {
     priceIds: {
       Monthly: Record<string, string>;
       Yearly: Record<string, string>;
@@ -9,6 +32,71 @@ interface DevPortalConfigsResponse {
   };
 }
 
+/**
+ * Fetch the raw dev-portal configs response.
+ *
+ * When `options.includeAgentPlan === true`, the `?agent=cli` query param is
+ * appended so the backend includes `stripe.priceIds.AgentPlan`. Without it,
+ * the Agent Plan priceId is omitted from the response.
+ */
+export async function fetchDevPortalConfigs(
+  jwt: string,
+  options?: { includeAgentPlan?: boolean },
+  userAgent?: string
+): Promise<DevPortalConfigsResponse> {
+  const path = options?.includeAgentPlan
+    ? "/dev-portal/configs?agent=cli"
+    : "/dev-portal/configs";
+  return authRequest<DevPortalConfigsResponse>(
+    path,
+    {
+      method: "GET",
+      headers: { Authorization: `Bearer ${jwt}` },
+    },
+    userAgent
+  );
+}
+
+/**
+ * Fetch the Stripe priceIds block from `/dev-portal/configs`.
+ *
+ * Returns `{ Monthly, Yearly, AgentPlan? }`. `AgentPlan` is only present
+ * when `options.includeAgentPlan === true`. This is the canonical source
+ * of plan price IDs for the SDK post-OpenPay migration.
+ */
+export async function fetchStripePriceIds(
+  jwt: string,
+  options?: { includeAgentPlan?: boolean },
+  userAgent?: string
+): Promise<DevPortalConfigsResponse["stripe"]["priceIds"]> {
+  const configs = await fetchDevPortalConfigs(jwt, options, userAgent);
+  return configs.stripe.priceIds;
+}
+
+/**
+ * Fetch the prepaid-credits price-lookup map from `/dev-portal/configs`.
+ *
+ * Returns a flat `Record<string, string>` keyed by lookup keys like
+ * `prepaid_credits_10_USDC` → Stripe price ID. Each unit of `qty` grants
+ * 1,000,000 credits at the backend (see
+ * `ts-services/dev-api-lambda/util/constant.ts` `PREPAID_CREDITS_PER_UNIT_QTY`).
+ */
+export async function fetchPrepaidCreditsPriceIds(
+  jwt: string,
+  userAgent?: string
+): Promise<Record<string, string>> {
+  const configs = await fetchDevPortalConfigs(jwt, undefined, userAgent);
+  return configs.stripe.prepaidCreditsPlans ?? {};
+}
+
+/**
+ * @deprecated Prefer `fetchStripePriceIds` or `fetchDevPortalConfigs`.
+ * Kept for backwards compatibility with existing SDK consumers. The
+ * backend's `openPay` response key is vestigial after the Stripe cutover;
+ * this helper now reads from `stripe.priceIds` under the hood so it keeps
+ * working, but the name is misleading and will be removed in a future
+ * major.
+ */
 export async function fetchOpenPayPriceIds(
   jwt: string,
   userAgent?: string
@@ -16,13 +104,6 @@ export async function fetchOpenPayPriceIds(
   Monthly: Record<string, string>;
   Yearly: Record<string, string>;
 }> {
-  const configs = await authRequest<DevPortalConfigsResponse>(
-    "/dev-portal/configs",
-    {
-      method: "GET",
-      headers: { Authorization: `Bearer ${jwt}` },
-    },
-    userAgent
-  );
-  return configs.openPay.priceIds;
+  const priceIds = await fetchStripePriceIds(jwt, undefined, userAgent);
+  return { Monthly: priceIds.Monthly, Yearly: priceIds.Yearly };
 }

--- a/src/auth/purchaseCredits.ts
+++ b/src/auth/purchaseCredits.ts
@@ -2,14 +2,13 @@ import type { PurchaseCreditsOptions, PurchaseCreditsResult } from "./types";
 import { getAddress } from "./getAddress";
 import { loadKeypair } from "./loadKeypair";
 import { listProjects } from "./listProjects";
-import { fetchPrepaidCreditsPriceIds } from "./devPortalConfigs";
+import { getProject } from "./getProject";
 import {
   initializeCheckout,
   pollCheckoutCompletion,
   payPaymentIntent,
 } from "./checkout";
 
-const DEFAULT_TIER = "10_USDC";
 const AGENT_PLAN_ID = "agent_v4";
 
 /**
@@ -31,7 +30,6 @@ export async function purchaseCredits(
   options: PurchaseCreditsOptions,
   userAgent?: string
 ): Promise<PurchaseCreditsResult> {
-  const tier = options.tier ?? DEFAULT_TIER;
   const qty = options.qty ?? 1;
 
   // 1. Pre-flight: confirm the project is on agent_v4.
@@ -51,17 +49,17 @@ export async function purchaseCredits(
     );
   }
 
-  // 2. Resolve tier → priceId from the flat prepaid-credits map.
-  const prepaidPriceIds = await fetchPrepaidCreditsPriceIds(jwt, userAgent);
-  const lookupKey = `prepaid_credits_${tier}`;
-  const priceId = prepaidPriceIds[lookupKey];
+  // 2. Resolve the top-up priceId from the project's own details.
+  // The backend derives this from planSpecifications.overageCost so it
+  // tracks each plan's prepaid-credits SKU automatically (agent_v4 →
+  // prepaid_credits_10_USDC). `tier` is unused in this SDK version.
+  const projectDetails = await getProject(jwt, options.projectId, userAgent);
+  const priceId = projectDetails.prepaidCreditsPriceId;
   if (!priceId) {
-    const available = Object.keys(prepaidPriceIds);
     throw new Error(
-      `Unknown prepaid-credits tier "${tier}". ` +
-        (available.length === 0
-          ? "The backend returned no prepaid-credits plans."
-          : `Available tiers: [${available.join(", ")}]`)
+      `Project ${options.projectId} does not expose a prepaid-credits priceId. ` +
+        `The backend may not have provisioned it yet — try again shortly, or ` +
+        `top up via the dashboard.`
     );
   }
 

--- a/src/auth/purchaseCredits.ts
+++ b/src/auth/purchaseCredits.ts
@@ -31,6 +31,11 @@ export async function purchaseCredits(
   userAgent?: string
 ): Promise<PurchaseCreditsResult> {
   const qty = options.qty ?? 1;
+  if (!Number.isInteger(qty) || qty < 1) {
+    throw new Error(
+      `purchaseCredits: \`qty\` must be a positive integer, received ${qty}.`
+    );
+  }
 
   // 1. Pre-flight: confirm the project is on agent_v4.
   const projects = await listProjects(jwt, userAgent);

--- a/src/auth/purchaseCredits.ts
+++ b/src/auth/purchaseCredits.ts
@@ -1,0 +1,126 @@
+import type { PurchaseCreditsOptions, PurchaseCreditsResult } from "./types";
+import { getAddress } from "./getAddress";
+import { loadKeypair } from "./loadKeypair";
+import { listProjects } from "./listProjects";
+import { fetchPrepaidCreditsPriceIds } from "./devPortalConfigs";
+import {
+  initializeCheckout,
+  pollCheckoutCompletion,
+  payPaymentIntent,
+} from "./checkout";
+
+const DEFAULT_TIER = "10_USDC";
+const AGENT_PLAN_ID = "agent_v4";
+
+/**
+ * Buy additional prepaid credits for an agent-plan project.
+ *
+ * Agent-only in this release: the SDK pre-flights the target project's
+ * plan before calling `/checkout/initialize`, because `payPaymentIntent`
+ * re-throws 4xx sponsor failures (see `payPaymentIntent.ts:22-38`) and
+ * a non-agent sponsored top-up would be rejected by the backend with a
+ * 400 — the pre-flight surfaces a clean client-side error instead of
+ * a raw backend rejection.
+ *
+ * Each unit of `qty` grants 1,000,000 credits (backend constant
+ * `PREPAID_CREDITS_PER_UNIT_QTY`).
+ */
+export async function purchaseCredits(
+  secretKey: Uint8Array,
+  jwt: string,
+  options: PurchaseCreditsOptions,
+  userAgent?: string
+): Promise<PurchaseCreditsResult> {
+  const tier = options.tier ?? DEFAULT_TIER;
+  const qty = options.qty ?? 1;
+
+  // 1. Pre-flight: confirm the project is on agent_v4.
+  const projects = await listProjects(jwt, userAgent);
+  const project = projects.find((p) => p.id === options.projectId);
+  if (!project) {
+    throw new Error(
+      `Project ${options.projectId} not found for this authenticated user.`
+    );
+  }
+  const currentPlan = project.subscription?.plan;
+  if (currentPlan !== AGENT_PLAN_ID) {
+    throw new Error(
+      `purchaseCredits is only supported for agent-plan projects in this ` +
+        `SDK version; project ${options.projectId} is on "${currentPlan ?? "unknown"}". ` +
+        `Other plans must top up via the dashboard.`
+    );
+  }
+
+  // 2. Resolve tier → priceId from the flat prepaid-credits map.
+  const prepaidPriceIds = await fetchPrepaidCreditsPriceIds(jwt, userAgent);
+  const lookupKey = `prepaid_credits_${tier}`;
+  const priceId = prepaidPriceIds[lookupKey];
+  if (!priceId) {
+    const available = Object.keys(prepaidPriceIds);
+    throw new Error(
+      `Unknown prepaid-credits tier "${tier}". ` +
+        (available.length === 0
+          ? "The backend returned no prepaid-credits plans."
+          : `Available tiers: [${available.join(", ")}]`)
+    );
+  }
+
+  // 3. Initialize a sponsored checkout for the top-up.
+  const keypair = loadKeypair(secretKey);
+  const payerWallet = await getAddress(keypair);
+  const intent = await initializeCheckout(
+    jwt,
+    {
+      priceId,
+      refId: options.projectId,
+      qty,
+      paymentMode: "sponsored",
+      signupWalletAddress: payerWallet,
+      walletAddress: payerWallet,
+      couponCode: options.couponCode,
+    },
+    userAgent
+  );
+
+  // 4. Pay — sponsored-first with infrastructure-only fallback.
+  let txSignature: string | null = null;
+  try {
+    txSignature =
+      (await payPaymentIntent(secretKey, intent, jwt, userAgent)) || null;
+  } catch (error) {
+    return {
+      paymentIntentId: intent.id,
+      txSignature: null,
+      status: "failed",
+      amountCents: intent.amount,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+
+  // 5. Poll for backend confirmation.
+  const status = await pollCheckoutCompletion(jwt, intent.id, userAgent);
+
+  if (status.phase === "failed" || status.phase === "expired") {
+    return {
+      paymentIntentId: intent.id,
+      txSignature,
+      status: status.phase,
+      amountCents: intent.amount,
+      error: status.message,
+    };
+  }
+  if (!status.readyToRedirect) {
+    return {
+      paymentIntentId: intent.id,
+      txSignature,
+      status: "timeout",
+      amountCents: intent.amount,
+    };
+  }
+  return {
+    paymentIntentId: intent.id,
+    txSignature,
+    status: "completed",
+    amountCents: intent.amount,
+  };
+}

--- a/src/auth/signupHelpers.ts
+++ b/src/auth/signupHelpers.ts
@@ -1,7 +1,11 @@
-import { OPENPAY_PLANS } from "./constants";
+import { AGENT_PLANS, OPENPAY_PLANS } from "./constants";
 
 export function isOpenPayPlan(plan: string): boolean {
   return (OPENPAY_PLANS as readonly string[]).includes(plan);
+}
+
+export function isAgentPlan(plan: string): boolean {
+  return (AGENT_PLANS as readonly string[]).includes(plan);
 }
 
 export function buildEndpoints(apiKey: string) {

--- a/src/auth/tests/agenticSignup.test.ts
+++ b/src/auth/tests/agenticSignup.test.ts
@@ -59,7 +59,14 @@ jest.mock("../checkout", () => ({
 
 import { agenticSignup } from "../agenticSignup";
 import { listProjects } from "../listProjects";
+import { walletSignup } from "../walletSignup";
 import { executeCheckout, executeUpgrade } from "../checkout";
+
+const CONTACT = {
+  email: "user@example.com",
+  firstName: "Test",
+  lastName: "User",
+};
 
 const EXISTING_PROJECT = {
   id: "proj-existing",
@@ -76,116 +83,59 @@ describe("agenticSignup", () => {
     jest.clearAllMocks();
   });
 
-  // ── Basic plan (now via checkout) ──
+  // ── Agent plan (new default entry plan) ──
 
-  describe("basic plan (via checkout)", () => {
-    it("creates a new project via checkout when no plan specified", async () => {
-      const result = await agenticSignup({ secretKey: new Uint8Array(64) });
-
-      expect(result.status).toBe("success");
-      expect(result.jwt).toBe("jwt-token-123");
-      expect(result.walletAddress).toBe("WalletAddress123");
-      expect(result.projectId).toBe("proj-new");
-      expect(result.apiKey).toBe("key-abc");
-      expect(result.txSignature).toBe("tx-sig-abc123");
-      expect(result.endpoints).toEqual({
-        mainnet: "https://mainnet.helius-rpc.com/?api-key=key-abc",
-        devnet: "https://devnet.helius-rpc.com/?api-key=key-abc",
+  describe("agent plan (default)", () => {
+    it("defaults to agent plan when plan is omitted", async () => {
+      const result = await agenticSignup({
+        secretKey: new Uint8Array(64),
+        ...CONTACT,
       });
 
+      expect(result.status).toBe("success");
       expect(executeCheckout).toHaveBeenCalledWith(
         new Uint8Array(64),
         "jwt-token-123",
-        {
-          plan: "basic",
-          period: "monthly",
-          refId: "ref-1",
-          email: undefined,
-          firstName: undefined,
-          lastName: undefined,
-          walletAddress: "WalletAddress123",
-          couponCode: undefined,
+        expect.objectContaining({
+          plan: "agent",
           paymentMode: "sponsored",
-        },
+        }),
         undefined
       );
     });
 
-    it("creates a new project via checkout when plan='basic'", async () => {
-      const result = await agenticSignup({
-        secretKey: new Uint8Array(64),
-        plan: "basic",
-      });
-
-      expect(result.status).toBe("success");
-      expect(executeCheckout).toHaveBeenCalledWith(
-        expect.any(Uint8Array),
-        "jwt-token-123",
-        expect.objectContaining({ plan: "basic" }),
-        undefined
-      );
-    });
-
-    it("treats empty string plan as basic", async () => {
-      await agenticSignup({ secretKey: new Uint8Array(64), plan: "" });
-
-      const callArgs = (executeCheckout as jest.Mock).mock.calls[0];
-      expect(callArgs[2].plan).toBe("basic");
-    });
-
-    it("returns existing project when one exists (basic plan)", async () => {
-      (listProjects as jest.Mock).mockResolvedValueOnce([EXISTING_PROJECT]);
-
-      const result = await agenticSignup({ secretKey: new Uint8Array(64) });
-
-      expect(result.status).toBe("existing_project");
-      expect(result.projectId).toBe("proj-existing");
-      expect(executeCheckout).not.toHaveBeenCalled();
-      expect(executeUpgrade).not.toHaveBeenCalled();
-    });
-
-    it("always sets paymentMode to sponsored for new signups", async () => {
+    it("treats empty string plan as agent", async () => {
       await agenticSignup({
         secretKey: new Uint8Array(64),
+        plan: "",
+        ...CONTACT,
+      });
+
+      const callArgs = (executeCheckout as jest.Mock).mock.calls[0];
+      expect(callArgs[2].plan).toBe("agent");
+    });
+
+    it("requires contact info for new-user agent signup", async () => {
+      await expect(
+        agenticSignup({ secretKey: new Uint8Array(64), plan: "agent" })
+      ).rejects.toThrow("Missing: email, firstName, lastName");
+    });
+
+    it("uses sponsored paymentMode for agent signups", async () => {
+      await agenticSignup({
+        secretKey: new Uint8Array(64),
+        plan: "agent",
+        ...CONTACT,
       });
 
       const callArgs = (executeCheckout as jest.Mock).mock.calls[0];
       expect(callArgs[2].paymentMode).toBe("sponsored");
-    });
-
-    it("passes userAgent through to checkout flow", async () => {
-      const { walletSignup } = require("../walletSignup");
-
-      await agenticSignup({
-        secretKey: new Uint8Array(64),
-        userAgent: "test-agent/1.0",
-      });
-
-      expect(walletSignup).toHaveBeenCalledWith(
-        "auth-msg",
-        "auth-sig",
-        "WalletAddress123",
-        "test-agent/1.0"
-      );
-
-      expect(executeCheckout).toHaveBeenCalledWith(
-        new Uint8Array(64),
-        "jwt-token-123",
-        expect.objectContaining({ plan: "basic", paymentMode: "sponsored" }),
-        "test-agent/1.0"
-      );
     });
   });
 
   // ── OpenPay signup (new user) ──
 
   describe("OpenPay signup (new user)", () => {
-    const CONTACT = {
-      email: "user@example.com",
-      firstName: "Test",
-      lastName: "User",
-    };
-
     it("uses executeCheckout for developer plan", async () => {
       const result = await agenticSignup({
         secretKey: new Uint8Array(64),
@@ -315,6 +265,60 @@ describe("agenticSignup", () => {
     });
   });
 
+  // ── Pre-authenticated session reuse ──
+
+  describe("pre-authenticated session (jwt + refId)", () => {
+    it("skips walletSignup when jwt + refId are supplied", async () => {
+      await agenticSignup({
+        secretKey: new Uint8Array(64),
+        plan: "developer",
+        jwt: "preauth-jwt",
+        refId: "preauth-ref",
+        ...CONTACT,
+      });
+
+      expect(walletSignup).not.toHaveBeenCalled();
+      expect(executeCheckout).toHaveBeenCalledWith(
+        new Uint8Array(64),
+        "preauth-jwt",
+        expect.objectContaining({ refId: "preauth-ref", plan: "developer" }),
+        undefined
+      );
+    });
+
+    it("throws when only jwt is supplied (no refId)", async () => {
+      await expect(
+        agenticSignup({
+          secretKey: new Uint8Array(64),
+          plan: "developer",
+          jwt: "preauth-jwt",
+          ...CONTACT,
+        })
+      ).rejects.toThrow("pass both `jwt` and `refId` together");
+    });
+
+    it("throws when only refId is supplied (no jwt)", async () => {
+      await expect(
+        agenticSignup({
+          secretKey: new Uint8Array(64),
+          plan: "developer",
+          refId: "preauth-ref",
+          ...CONTACT,
+        })
+      ).rejects.toThrow("pass both `jwt` and `refId` together");
+    });
+
+    it("calls walletSignup normally when neither is supplied", async () => {
+      await agenticSignup({
+        secretKey: new Uint8Array(64),
+        plan: "developer",
+        ...CONTACT,
+      });
+
+      expect(walletSignup).toHaveBeenCalledTimes(1);
+    });
+  });
+
   // ── Existing user + paid plan → upgrade ──
 
   describe("existing user + paid plan (upgrade)", () => {
@@ -326,9 +330,7 @@ describe("agenticSignup", () => {
         plan: "business",
         period: "yearly",
         couponCode: "UPGRADE10",
-        email: "user@example.com",
-        firstName: "Test",
-        lastName: "User",
+        ...CONTACT,
       });
 
       expect(result.status).toBe("upgraded");
@@ -345,9 +347,7 @@ describe("agenticSignup", () => {
           period: "yearly",
           refId: "proj-existing",
           couponCode: "UPGRADE10",
-          email: "user@example.com",
-          firstName: "Test",
-          lastName: "User",
+          ...CONTACT,
         },
         undefined,
         { skipProjectPolling: true }
@@ -397,6 +397,28 @@ describe("agenticSignup", () => {
       expect(callArgs[2].paymentMode).toBeUndefined();
     });
 
+    it("existing user + agent plan routes through upgrade flow", async () => {
+      (listProjects as jest.Mock).mockResolvedValueOnce([EXISTING_PROJECT]);
+
+      const result = await agenticSignup({
+        secretKey: new Uint8Array(64),
+        plan: "agent",
+        ...CONTACT,
+      });
+
+      expect(result.status).toBe("upgraded");
+      expect(executeCheckout).toHaveBeenCalledWith(
+        new Uint8Array(64),
+        "jwt-token-123",
+        expect.objectContaining({
+          plan: "agent",
+          refId: "proj-existing",
+        }),
+        undefined,
+        { skipProjectPolling: true }
+      );
+    });
+
     it("throws on partial customer info for existing user upgrade", async () => {
       (listProjects as jest.Mock).mockResolvedValueOnce([EXISTING_PROJECT]);
 
@@ -433,10 +455,16 @@ describe("agenticSignup", () => {
       ).rejects.toThrow("Unknown plan: enterprise");
     });
 
+    it("rejects basic (removed from supported set)", async () => {
+      await expect(
+        agenticSignup({ secretKey: new Uint8Array(64), plan: "basic" })
+      ).rejects.toThrow("Unknown plan: basic");
+    });
+
     it("throws on unknown plan with available plans listed", async () => {
       await expect(
         agenticSignup({ secretKey: new Uint8Array(64), plan: "invalid" })
-      ).rejects.toThrow("Available: basic, developer, business, professional");
+      ).rejects.toThrow("Available: developer, business, professional, agent");
     });
   });
 });

--- a/src/auth/tests/checkout.test.ts
+++ b/src/auth/tests/checkout.test.ts
@@ -15,7 +15,7 @@ import { listProjects } from "../listProjects";
 import { getProject } from "../getProject";
 import { loadKeypair } from "../loadKeypair";
 import { getAddress } from "../getAddress";
-import { fetchOpenPayPriceIds } from "../devPortalConfigs";
+import { fetchStripePriceIds } from "../devPortalConfigs";
 import { paySponsoredIntent } from "../sponsoredPayment";
 
 jest.mock("../utils");
@@ -51,8 +51,8 @@ const mockListProjects = listProjects as jest.MockedFunction<
 const mockGetProject = getProject as jest.MockedFunction<typeof getProject>;
 const mockLoadKeypair = loadKeypair as jest.MockedFunction<typeof loadKeypair>;
 const mockGetAddress = getAddress as jest.MockedFunction<typeof getAddress>;
-const mockFetchOpenPayPriceIds = fetchOpenPayPriceIds as jest.MockedFunction<
-  typeof fetchOpenPayPriceIds
+const mockFetchStripePriceIds = fetchStripePriceIds as jest.MockedFunction<
+  typeof fetchStripePriceIds
 >;
 const mockPaySponsoredIntent = paySponsoredIntent as jest.MockedFunction<
   typeof paySponsoredIntent
@@ -60,17 +60,20 @@ const mockPaySponsoredIntent = paySponsoredIntent as jest.MockedFunction<
 
 const MOCK_PRICE_IDS = {
   Monthly: {
-    basic: "price_basic_monthly",
     developer_v4: "price_dev_monthly",
     business_v4: "price_biz_monthly",
     professional_v4: "price_pro_monthly",
   },
   Yearly: {
-    basic: "price_basic_yearly",
     developer_v4: "price_dev_yearly",
     business_v4: "price_biz_yearly",
     professional_v4: "price_pro_yearly",
   },
+};
+
+const MOCK_PRICE_IDS_WITH_AGENT = {
+  ...MOCK_PRICE_IDS,
+  AgentPlan: "price_agent_plan",
 };
 
 const INIT_RESPONSE = {
@@ -96,28 +99,58 @@ const POLL_COMPLETED_RESPONSE = {
 describe("resolvePriceId", () => {
   beforeEach(() => jest.resetAllMocks());
 
-  it("resolves basic monthly", async () => {
-    mockFetchOpenPayPriceIds.mockResolvedValue(MOCK_PRICE_IDS);
-    const result = await resolvePriceId("jwt", "basic", "monthly");
-    expect(result).toBe("price_basic_monthly");
-  });
-
   it("resolves developer monthly", async () => {
-    mockFetchOpenPayPriceIds.mockResolvedValue(MOCK_PRICE_IDS);
+    mockFetchStripePriceIds.mockResolvedValue(MOCK_PRICE_IDS);
     const result = await resolvePriceId("jwt", "developer", "monthly");
     expect(result).toBe("price_dev_monthly");
   });
 
   it("resolves business yearly", async () => {
-    mockFetchOpenPayPriceIds.mockResolvedValue(MOCK_PRICE_IDS);
+    mockFetchStripePriceIds.mockResolvedValue(MOCK_PRICE_IDS);
     const result = await resolvePriceId("jwt", "business", "yearly");
     expect(result).toBe("price_biz_yearly");
   });
 
   it("is case-insensitive for plan name", async () => {
-    mockFetchOpenPayPriceIds.mockResolvedValue(MOCK_PRICE_IDS);
+    mockFetchStripePriceIds.mockResolvedValue(MOCK_PRICE_IDS);
     const result = await resolvePriceId("jwt", "Developer", "monthly");
     expect(result).toBe("price_dev_monthly");
+  });
+
+  it("resolves agent plan and auto-sends ?agent=cli", async () => {
+    mockFetchStripePriceIds.mockResolvedValue(MOCK_PRICE_IDS_WITH_AGENT);
+    const result = await resolvePriceId("jwt", "agent", "monthly");
+    expect(result).toBe("price_agent_plan");
+    expect(mockFetchStripePriceIds).toHaveBeenCalledWith(
+      "jwt",
+      { includeAgentPlan: true },
+      undefined
+    );
+  });
+
+  it("ignores period for agent plan", async () => {
+    mockFetchStripePriceIds.mockResolvedValue(MOCK_PRICE_IDS_WITH_AGENT);
+    const monthly = await resolvePriceId("jwt", "agent", "monthly");
+    const yearly = await resolvePriceId("jwt", "agent", "yearly");
+    expect(monthly).toBe("price_agent_plan");
+    expect(yearly).toBe("price_agent_plan");
+  });
+
+  it("throws when AgentPlan is missing from response", async () => {
+    mockFetchStripePriceIds.mockResolvedValue(MOCK_PRICE_IDS);
+    await expect(resolvePriceId("jwt", "agent", "monthly")).rejects.toThrow(
+      /stripe\.priceIds\.AgentPlan|PRICE_ID_AGENT_PLAN/
+    );
+  });
+
+  it("does NOT send ?agent=cli for non-agent plans (dashboard regression guard)", async () => {
+    mockFetchStripePriceIds.mockResolvedValue(MOCK_PRICE_IDS);
+    await resolvePriceId("jwt", "developer", "monthly");
+    expect(mockFetchStripePriceIds).toHaveBeenCalledWith(
+      "jwt",
+      undefined,
+      undefined
+    );
   });
 
   it("throws for unknown plan", async () => {
@@ -126,14 +159,20 @@ describe("resolvePriceId", () => {
     ).rejects.toThrow("Unknown plan: enterprise");
   });
 
-  it("includes available plans in error", async () => {
+  it("rejects basic with Unknown plan error (removed from supported set)", async () => {
+    await expect(resolvePriceId("jwt", "basic", "monthly")).rejects.toThrow(
+      "Unknown plan: basic"
+    );
+  });
+
+  it("includes available plans in error (basic absent, agent present)", async () => {
     await expect(resolvePriceId("jwt", "invalid", "monthly")).rejects.toThrow(
-      "Available: basic, developer, business, professional"
+      "Available: developer, business, professional, agent"
     );
   });
 
   it("throws when priceId not found in configs (empty)", async () => {
-    mockFetchOpenPayPriceIds.mockResolvedValue({
+    mockFetchStripePriceIds.mockResolvedValue({
       Monthly: {},
       Yearly: {},
     });
@@ -143,7 +182,7 @@ describe("resolvePriceId", () => {
   });
 
   it("throws with available keys when key mismatch", async () => {
-    mockFetchOpenPayPriceIds.mockResolvedValue({
+    mockFetchStripePriceIds.mockResolvedValue({
       Monthly: { some_other_plan: "price_unknown" },
       Yearly: {},
     });
@@ -295,7 +334,7 @@ describe("executeCheckout", () => {
   const mockSecretKey = new Uint8Array(64).fill(1);
 
   function setupDefaultMocks() {
-    mockFetchOpenPayPriceIds.mockResolvedValue(MOCK_PRICE_IDS);
+    mockFetchStripePriceIds.mockResolvedValue(MOCK_PRICE_IDS);
     mockLoadKeypair.mockReturnValue({
       publicKey: new Uint8Array(32),
       secretKey: mockSecretKey,
@@ -476,7 +515,7 @@ describe("executeCheckout", () => {
 describe("getCheckoutPreview", () => {
   beforeEach(() => {
     jest.resetAllMocks();
-    mockFetchOpenPayPriceIds.mockResolvedValue(MOCK_PRICE_IDS);
+    mockFetchStripePriceIds.mockResolvedValue(MOCK_PRICE_IDS);
   });
 
   it("resolves priceId and sends GET to /checkout/preview with query params", async () => {
@@ -561,7 +600,7 @@ describe("getPaymentStatus", () => {
 describe("getSignupQuote", () => {
   beforeEach(() => {
     jest.resetAllMocks();
-    mockFetchOpenPayPriceIds.mockResolvedValue(MOCK_PRICE_IDS);
+    mockFetchStripePriceIds.mockResolvedValue(MOCK_PRICE_IDS);
   });
 
   it("returns simplified quote from checkout preview", async () => {
@@ -601,7 +640,7 @@ describe("getSignupQuote", () => {
 describe("initializeSignupFunding", () => {
   beforeEach(() => {
     jest.resetAllMocks();
-    mockFetchOpenPayPriceIds.mockResolvedValue(MOCK_PRICE_IDS);
+    mockFetchStripePriceIds.mockResolvedValue(MOCK_PRICE_IDS);
   });
 
   it("resolves priceId and returns funding intent with sponsored mode", async () => {
@@ -633,7 +672,7 @@ describe("initializeSignupFunding", () => {
     mockAuthRequest.mockResolvedValue(INIT_RESPONSE);
 
     const funding = await initializeSignupFunding("jwt", {
-      plan: "basic",
+      plan: "developer",
       period: "monthly",
       refId: "ref-1",
     });

--- a/src/auth/tests/checkoutPreview.test.ts
+++ b/src/auth/tests/checkoutPreview.test.ts
@@ -1,13 +1,13 @@
 import { getCheckoutPreview } from "../checkout";
 import { authRequest } from "../utils";
-import { fetchOpenPayPriceIds } from "../devPortalConfigs";
+import { fetchStripePriceIds } from "../devPortalConfigs";
 
 jest.mock("../utils");
 jest.mock("../devPortalConfigs");
 
 const mockAuthRequest = authRequest as jest.MockedFunction<typeof authRequest>;
-const mockFetchOpenPayPriceIds = fetchOpenPayPriceIds as jest.MockedFunction<
-  typeof fetchOpenPayPriceIds
+const mockFetchStripePriceIds = fetchStripePriceIds as jest.MockedFunction<
+  typeof fetchStripePriceIds
 >;
 
 const MOCK_PRICE_IDS = {
@@ -26,7 +26,7 @@ const MOCK_PRICE_IDS = {
 describe("getCheckoutPreview", () => {
   beforeEach(() => {
     jest.resetAllMocks();
-    mockFetchOpenPayPriceIds.mockResolvedValue(MOCK_PRICE_IDS);
+    mockFetchStripePriceIds.mockResolvedValue(MOCK_PRICE_IDS);
   });
 
   it("fetches preview with all params", async () => {

--- a/src/auth/tests/devPortalConfigs.test.ts
+++ b/src/auth/tests/devPortalConfigs.test.ts
@@ -1,0 +1,174 @@
+import {
+  fetchDevPortalConfigs,
+  fetchStripePriceIds,
+  fetchPrepaidCreditsPriceIds,
+  fetchOpenPayPriceIds,
+} from "../devPortalConfigs";
+import { authRequest } from "../utils";
+
+jest.mock("../utils");
+
+const mockAuthRequest = authRequest as jest.MockedFunction<typeof authRequest>;
+
+const MOCK_CONFIGS = {
+  stripe: {
+    priceIds: {
+      Monthly: {
+        developer_v4: "price_dev_monthly",
+        business_v4: "price_biz_monthly",
+        professional_v4: "price_pro_monthly",
+      },
+      Yearly: {
+        developer_v4: "price_dev_yearly",
+        business_v4: "price_biz_yearly",
+        professional_v4: "price_pro_yearly",
+      },
+    },
+    prepaidCreditsPlans: {
+      prepaid_credits_4_USDC: "price_prepaid_4",
+      prepaid_credits_5_USDC: "price_prepaid_5",
+      prepaid_credits_10_USDC: "price_prepaid_10",
+    },
+  },
+};
+
+const MOCK_CONFIGS_WITH_AGENT = {
+  stripe: {
+    ...MOCK_CONFIGS.stripe,
+    priceIds: {
+      ...MOCK_CONFIGS.stripe.priceIds,
+      AgentPlan: "price_agent_plan",
+    },
+  },
+};
+
+describe("fetchDevPortalConfigs", () => {
+  beforeEach(() => jest.resetAllMocks());
+
+  it("fetches /dev-portal/configs without query when includeAgentPlan is omitted", async () => {
+    mockAuthRequest.mockResolvedValue(MOCK_CONFIGS);
+
+    const result = await fetchDevPortalConfigs("jwt");
+
+    expect(mockAuthRequest).toHaveBeenCalledWith(
+      "/dev-portal/configs",
+      { method: "GET", headers: { Authorization: "Bearer jwt" } },
+      undefined
+    );
+    expect(result).toBe(MOCK_CONFIGS);
+  });
+
+  it("appends ?agent=cli when includeAgentPlan is true", async () => {
+    mockAuthRequest.mockResolvedValue(MOCK_CONFIGS_WITH_AGENT);
+
+    await fetchDevPortalConfigs("jwt", { includeAgentPlan: true });
+
+    expect(mockAuthRequest).toHaveBeenCalledWith(
+      "/dev-portal/configs?agent=cli",
+      { method: "GET", headers: { Authorization: "Bearer jwt" } },
+      undefined
+    );
+  });
+
+  it("does NOT append ?agent=cli when includeAgentPlan is false (dashboard regression guard)", async () => {
+    mockAuthRequest.mockResolvedValue(MOCK_CONFIGS);
+
+    await fetchDevPortalConfigs("jwt", { includeAgentPlan: false });
+
+    expect(mockAuthRequest).toHaveBeenCalledWith(
+      "/dev-portal/configs",
+      expect.any(Object),
+      undefined
+    );
+  });
+
+  it("forwards userAgent to authRequest", async () => {
+    mockAuthRequest.mockResolvedValue(MOCK_CONFIGS);
+
+    await fetchDevPortalConfigs("jwt", undefined, "helius-cli/1.0");
+
+    expect(mockAuthRequest).toHaveBeenCalledWith(
+      "/dev-portal/configs",
+      expect.any(Object),
+      "helius-cli/1.0"
+    );
+  });
+});
+
+describe("fetchStripePriceIds", () => {
+  beforeEach(() => jest.resetAllMocks());
+
+  it("returns stripe.priceIds without AgentPlan by default", async () => {
+    mockAuthRequest.mockResolvedValue(MOCK_CONFIGS);
+
+    const result = await fetchStripePriceIds("jwt");
+
+    expect(result.Monthly.developer_v4).toBe("price_dev_monthly");
+    expect(result.Yearly.professional_v4).toBe("price_pro_yearly");
+    expect(result.AgentPlan).toBeUndefined();
+  });
+
+  it("returns AgentPlan when includeAgentPlan is true", async () => {
+    mockAuthRequest.mockResolvedValue(MOCK_CONFIGS_WITH_AGENT);
+
+    const result = await fetchStripePriceIds("jwt", { includeAgentPlan: true });
+
+    expect(result.AgentPlan).toBe("price_agent_plan");
+  });
+});
+
+describe("fetchPrepaidCreditsPriceIds", () => {
+  beforeEach(() => jest.resetAllMocks());
+
+  it("returns the flat prepaidCreditsPlans record", async () => {
+    mockAuthRequest.mockResolvedValue(MOCK_CONFIGS);
+
+    const result = await fetchPrepaidCreditsPriceIds("jwt");
+
+    expect(result.prepaid_credits_10_USDC).toBe("price_prepaid_10");
+    expect(result.prepaid_credits_4_USDC).toBe("price_prepaid_4");
+  });
+
+  it("returns an empty object when backend omits prepaidCreditsPlans", async () => {
+    mockAuthRequest.mockResolvedValue({
+      stripe: { priceIds: MOCK_CONFIGS.stripe.priceIds },
+    });
+
+    const result = await fetchPrepaidCreditsPriceIds("jwt");
+
+    expect(result).toEqual({});
+  });
+
+  it("does NOT send ?agent=cli", async () => {
+    mockAuthRequest.mockResolvedValue(MOCK_CONFIGS);
+
+    await fetchPrepaidCreditsPriceIds("jwt");
+
+    expect(mockAuthRequest).toHaveBeenCalledWith(
+      "/dev-portal/configs",
+      expect.any(Object),
+      undefined
+    );
+  });
+});
+
+describe("fetchOpenPayPriceIds (deprecated wrapper)", () => {
+  beforeEach(() => jest.resetAllMocks());
+
+  it("returns {Monthly, Yearly} sourced from stripe.priceIds", async () => {
+    mockAuthRequest.mockResolvedValue(MOCK_CONFIGS);
+
+    const result = await fetchOpenPayPriceIds("jwt");
+
+    expect(result).toEqual({
+      Monthly: MOCK_CONFIGS.stripe.priceIds.Monthly,
+      Yearly: MOCK_CONFIGS.stripe.priceIds.Yearly,
+    });
+    // Wrapper does not send ?agent=cli
+    expect(mockAuthRequest).toHaveBeenCalledWith(
+      "/dev-portal/configs",
+      expect.any(Object),
+      undefined
+    );
+  });
+});

--- a/src/auth/tests/purchaseCredits.test.ts
+++ b/src/auth/tests/purchaseCredits.test.ts
@@ -1,0 +1,241 @@
+import { purchaseCredits } from "../purchaseCredits";
+import { listProjects } from "../listProjects";
+import { fetchPrepaidCreditsPriceIds } from "../devPortalConfigs";
+import {
+  initializeCheckout,
+  payPaymentIntent,
+  pollCheckoutCompletion,
+} from "../checkout";
+import { loadKeypair } from "../loadKeypair";
+import { getAddress } from "../getAddress";
+
+jest.mock("../listProjects");
+jest.mock("../devPortalConfigs");
+jest.mock("../checkout");
+jest.mock("../loadKeypair");
+jest.mock("../getAddress");
+
+const mockListProjects = listProjects as jest.MockedFunction<
+  typeof listProjects
+>;
+const mockFetchPrepaidCreditsPriceIds =
+  fetchPrepaidCreditsPriceIds as jest.MockedFunction<
+    typeof fetchPrepaidCreditsPriceIds
+  >;
+const mockInitializeCheckout = initializeCheckout as jest.MockedFunction<
+  typeof initializeCheckout
+>;
+const mockPayPaymentIntent = payPaymentIntent as jest.MockedFunction<
+  typeof payPaymentIntent
+>;
+const mockPollCheckoutCompletion =
+  pollCheckoutCompletion as jest.MockedFunction<typeof pollCheckoutCompletion>;
+const mockLoadKeypair = loadKeypair as jest.MockedFunction<typeof loadKeypair>;
+const mockGetAddress = getAddress as jest.MockedFunction<typeof getAddress>;
+
+const AGENT_PROJECT = {
+  id: "proj-agent",
+  name: "Agent Project",
+  createdAt: "2025-01-01",
+  verifiedEmail: null,
+  subscription: { plan: "agent_v4" },
+  users: [],
+  dnsRecords: [],
+} as never;
+
+const DEVELOPER_PROJECT = {
+  id: "proj-dev",
+  name: "Dev Project",
+  createdAt: "2025-01-01",
+  verifiedEmail: null,
+  subscription: { plan: "developer_v4" },
+  users: [],
+  dnsRecords: [],
+} as never;
+
+const INIT_RESPONSE = {
+  id: "pi_topup",
+  status: "pending",
+  destinationWallet: "Treasury111",
+  amount: 1000, // 10 USDC in cents
+  solanaPayUrl: "solana:...",
+  expiresAt: "2026-01-01T00:00:00Z",
+  createdAt: "2025-12-01T00:00:00Z",
+  priceId: "price_prepaid_10",
+  refId: "proj-agent",
+} as never;
+
+const POLL_COMPLETED = {
+  status: "completed",
+  phase: "complete",
+  subscriptionActive: true,
+  readyToRedirect: true,
+  message: "ok",
+} as never;
+
+describe("purchaseCredits", () => {
+  const secretKey = new Uint8Array(64);
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    mockLoadKeypair.mockReturnValue({
+      publicKey: new Uint8Array(32),
+      secretKey,
+    });
+    mockGetAddress.mockResolvedValue("WalletAgent111");
+    mockListProjects.mockResolvedValue([AGENT_PROJECT]);
+    mockFetchPrepaidCreditsPriceIds.mockResolvedValue({
+      prepaid_credits_4_USDC: "price_prepaid_4",
+      prepaid_credits_5_USDC: "price_prepaid_5",
+      prepaid_credits_10_USDC: "price_prepaid_10",
+    });
+    mockInitializeCheckout.mockResolvedValue(INIT_RESPONSE);
+    mockPayPaymentIntent.mockResolvedValue("tx-topup-sig");
+    mockPollCheckoutCompletion.mockResolvedValue(POLL_COMPLETED);
+  });
+
+  it("completes happy path for agent project with default 10_USDC tier", async () => {
+    const result = await purchaseCredits(secretKey, "jwt", {
+      projectId: "proj-agent",
+    });
+
+    expect(result.status).toBe("completed");
+    expect(result.txSignature).toBe("tx-topup-sig");
+    expect(result.paymentIntentId).toBe("pi_topup");
+    expect(result.amountCents).toBe(1000);
+
+    // Default tier resolves to prepaid_credits_10_USDC
+    expect(mockInitializeCheckout).toHaveBeenCalledWith(
+      "jwt",
+      expect.objectContaining({
+        priceId: "price_prepaid_10",
+        refId: "proj-agent",
+        qty: 1,
+        paymentMode: "sponsored",
+        signupWalletAddress: "WalletAgent111",
+        walletAddress: "WalletAgent111",
+      }),
+      undefined
+    );
+
+    // Sponsored payment flow receives jwt (enables sponsored-first attempt)
+    expect(mockPayPaymentIntent).toHaveBeenCalledWith(
+      secretKey,
+      INIT_RESPONSE,
+      "jwt",
+      undefined
+    );
+  });
+
+  it("rejects non-agent projects in pre-flight before /checkout/initialize", async () => {
+    mockListProjects.mockResolvedValue([DEVELOPER_PROJECT]);
+
+    await expect(
+      purchaseCredits(secretKey, "jwt", { projectId: "proj-dev" })
+    ).rejects.toThrow(/only supported for agent-plan projects/);
+
+    expect(mockInitializeCheckout).not.toHaveBeenCalled();
+    expect(mockPayPaymentIntent).not.toHaveBeenCalled();
+  });
+
+  it("rejects when project is not found for this user", async () => {
+    mockListProjects.mockResolvedValue([AGENT_PROJECT]);
+
+    await expect(
+      purchaseCredits(secretKey, "jwt", { projectId: "proj-other" })
+    ).rejects.toThrow(/not found for this authenticated user/);
+  });
+
+  it("forwards qty > 1 to initializeCheckout", async () => {
+    await purchaseCredits(secretKey, "jwt", {
+      projectId: "proj-agent",
+      qty: 3,
+    });
+
+    expect(mockInitializeCheckout).toHaveBeenCalledWith(
+      "jwt",
+      expect.objectContaining({ qty: 3 }),
+      undefined
+    );
+  });
+
+  it("throws with available tiers when tier is unknown", async () => {
+    await expect(
+      purchaseCredits(secretKey, "jwt", {
+        projectId: "proj-agent",
+        tier: "999_USDC",
+      })
+    ).rejects.toThrow(/Unknown prepaid-credits tier "999_USDC"/);
+  });
+
+  it("accepts an arbitrary tier key present on the backend (future-proof)", async () => {
+    mockFetchPrepaidCreditsPriceIds.mockResolvedValue({
+      prepaid_credits_25_USDC: "price_prepaid_25",
+    });
+
+    const result = await purchaseCredits(secretKey, "jwt", {
+      projectId: "proj-agent",
+      tier: "25_USDC",
+    });
+
+    expect(result.status).toBe("completed");
+    expect(mockInitializeCheckout).toHaveBeenCalledWith(
+      "jwt",
+      expect.objectContaining({ priceId: "price_prepaid_25" }),
+      undefined
+    );
+  });
+
+  it("returns failed status when payPaymentIntent throws", async () => {
+    mockPayPaymentIntent.mockRejectedValue(new Error("boom"));
+
+    const result = await purchaseCredits(secretKey, "jwt", {
+      projectId: "proj-agent",
+    });
+
+    expect(result.status).toBe("failed");
+    expect(result.txSignature).toBeNull();
+    expect(result.error).toBe("boom");
+  });
+
+  it("returns expired status when polling reports expired phase", async () => {
+    mockPollCheckoutCompletion.mockResolvedValue({
+      status: "expired",
+      phase: "expired",
+      subscriptionActive: false,
+      readyToRedirect: false,
+      message: "Payment intent expired",
+    } as never);
+
+    const result = await purchaseCredits(secretKey, "jwt", {
+      projectId: "proj-agent",
+    });
+
+    expect(result.status).toBe("expired");
+    expect(result.txSignature).toBe("tx-topup-sig");
+  });
+
+  it("returns timeout status when polling does not reach readyToRedirect", async () => {
+    mockPollCheckoutCompletion.mockResolvedValue({
+      status: "pending",
+      phase: "confirming",
+      subscriptionActive: false,
+      readyToRedirect: false,
+      message: "Still waiting",
+    } as never);
+
+    const result = await purchaseCredits(secretKey, "jwt", {
+      projectId: "proj-agent",
+    });
+
+    expect(result.status).toBe("timeout");
+  });
+
+  it("throws when backend returns no prepaid-credits plans", async () => {
+    mockFetchPrepaidCreditsPriceIds.mockResolvedValue({});
+
+    await expect(
+      purchaseCredits(secretKey, "jwt", { projectId: "proj-agent" })
+    ).rejects.toThrow(/returned no prepaid-credits plans/);
+  });
+});

--- a/src/auth/tests/purchaseCredits.test.ts
+++ b/src/auth/tests/purchaseCredits.test.ts
@@ -150,6 +150,22 @@ describe("purchaseCredits", () => {
     ).rejects.toThrow(/not found for this authenticated user/);
   });
 
+  it.each([0, -1, 1.5, NaN])(
+    "rejects non-positive-integer qty (%s) before any network calls",
+    async (badQty) => {
+      await expect(
+        purchaseCredits(secretKey, "jwt", {
+          projectId: "proj-agent",
+          qty: badQty,
+        })
+      ).rejects.toThrow(/`qty` must be a positive integer/);
+
+      expect(mockListProjects).not.toHaveBeenCalled();
+      expect(mockGetProject).not.toHaveBeenCalled();
+      expect(mockInitializeCheckout).not.toHaveBeenCalled();
+    }
+  );
+
   it("forwards qty > 1 to initializeCheckout", async () => {
     await purchaseCredits(secretKey, "jwt", {
       projectId: "proj-agent",

--- a/src/auth/tests/purchaseCredits.test.ts
+++ b/src/auth/tests/purchaseCredits.test.ts
@@ -1,6 +1,6 @@
 import { purchaseCredits } from "../purchaseCredits";
 import { listProjects } from "../listProjects";
-import { fetchPrepaidCreditsPriceIds } from "../devPortalConfigs";
+import { getProject } from "../getProject";
 import {
   initializeCheckout,
   payPaymentIntent,
@@ -10,7 +10,7 @@ import { loadKeypair } from "../loadKeypair";
 import { getAddress } from "../getAddress";
 
 jest.mock("../listProjects");
-jest.mock("../devPortalConfigs");
+jest.mock("../getProject");
 jest.mock("../checkout");
 jest.mock("../loadKeypair");
 jest.mock("../getAddress");
@@ -18,10 +18,7 @@ jest.mock("../getAddress");
 const mockListProjects = listProjects as jest.MockedFunction<
   typeof listProjects
 >;
-const mockFetchPrepaidCreditsPriceIds =
-  fetchPrepaidCreditsPriceIds as jest.MockedFunction<
-    typeof fetchPrepaidCreditsPriceIds
-  >;
+const mockGetProject = getProject as jest.MockedFunction<typeof getProject>;
 const mockInitializeCheckout = initializeCheckout as jest.MockedFunction<
   typeof initializeCheckout
 >;
@@ -51,6 +48,15 @@ const DEVELOPER_PROJECT = {
   subscription: { plan: "developer_v4" },
   users: [],
   dnsRecords: [],
+} as never;
+
+const AGENT_PROJECT_DETAILS = {
+  apiKeys: [],
+  creditsUsage: {} as never,
+  billingCycle: {} as never,
+  subscriptionPlanDetails: {} as never,
+  prepaidCreditsLink: "",
+  prepaidCreditsPriceId: "price_prepaid_10",
 } as never;
 
 const INIT_RESPONSE = {
@@ -84,17 +90,13 @@ describe("purchaseCredits", () => {
     });
     mockGetAddress.mockResolvedValue("WalletAgent111");
     mockListProjects.mockResolvedValue([AGENT_PROJECT]);
-    mockFetchPrepaidCreditsPriceIds.mockResolvedValue({
-      prepaid_credits_4_USDC: "price_prepaid_4",
-      prepaid_credits_5_USDC: "price_prepaid_5",
-      prepaid_credits_10_USDC: "price_prepaid_10",
-    });
+    mockGetProject.mockResolvedValue(AGENT_PROJECT_DETAILS);
     mockInitializeCheckout.mockResolvedValue(INIT_RESPONSE);
     mockPayPaymentIntent.mockResolvedValue("tx-topup-sig");
     mockPollCheckoutCompletion.mockResolvedValue(POLL_COMPLETED);
   });
 
-  it("completes happy path for agent project with default 10_USDC tier", async () => {
+  it("completes happy path for agent project, sourcing priceId from getProject", async () => {
     const result = await purchaseCredits(secretKey, "jwt", {
       projectId: "proj-agent",
     });
@@ -104,7 +106,8 @@ describe("purchaseCredits", () => {
     expect(result.paymentIntentId).toBe("pi_topup");
     expect(result.amountCents).toBe(1000);
 
-    // Default tier resolves to prepaid_credits_10_USDC
+    // priceId comes from getProject(...).prepaidCreditsPriceId
+    expect(mockGetProject).toHaveBeenCalledWith("jwt", "proj-agent", undefined);
     expect(mockInitializeCheckout).toHaveBeenCalledWith(
       "jwt",
       expect.objectContaining({
@@ -134,6 +137,7 @@ describe("purchaseCredits", () => {
       purchaseCredits(secretKey, "jwt", { projectId: "proj-dev" })
     ).rejects.toThrow(/only supported for agent-plan projects/);
 
+    expect(mockGetProject).not.toHaveBeenCalled();
     expect(mockInitializeCheckout).not.toHaveBeenCalled();
     expect(mockPayPaymentIntent).not.toHaveBeenCalled();
   });
@@ -159,31 +163,19 @@ describe("purchaseCredits", () => {
     );
   });
 
-  it("throws with available tiers when tier is unknown", async () => {
+  it("throws when project has no prepaidCreditsPriceId", async () => {
+    mockGetProject.mockResolvedValue({
+      apiKeys: [],
+      creditsUsage: {} as never,
+      billingCycle: {} as never,
+      subscriptionPlanDetails: {} as never,
+      prepaidCreditsLink: "",
+      // prepaidCreditsPriceId intentionally omitted
+    } as never);
+
     await expect(
-      purchaseCredits(secretKey, "jwt", {
-        projectId: "proj-agent",
-        tier: "999_USDC",
-      })
-    ).rejects.toThrow(/Unknown prepaid-credits tier "999_USDC"/);
-  });
-
-  it("accepts an arbitrary tier key present on the backend (future-proof)", async () => {
-    mockFetchPrepaidCreditsPriceIds.mockResolvedValue({
-      prepaid_credits_25_USDC: "price_prepaid_25",
-    });
-
-    const result = await purchaseCredits(secretKey, "jwt", {
-      projectId: "proj-agent",
-      tier: "25_USDC",
-    });
-
-    expect(result.status).toBe("completed");
-    expect(mockInitializeCheckout).toHaveBeenCalledWith(
-      "jwt",
-      expect.objectContaining({ priceId: "price_prepaid_25" }),
-      undefined
-    );
+      purchaseCredits(secretKey, "jwt", { projectId: "proj-agent" })
+    ).rejects.toThrow(/does not expose a prepaid-credits priceId/);
   });
 
   it("returns failed status when payPaymentIntent throws", async () => {
@@ -229,13 +221,5 @@ describe("purchaseCredits", () => {
     });
 
     expect(result.status).toBe("timeout");
-  });
-
-  it("throws when backend returns no prepaid-credits plans", async () => {
-    mockFetchPrepaidCreditsPriceIds.mockResolvedValue({});
-
-    await expect(
-      purchaseCredits(secretKey, "jwt", { projectId: "proj-agent" })
-    ).rejects.toThrow(/returned no prepaid-credits plans/);
   });
 });

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -312,6 +312,7 @@ export interface PurchaseCreditsOptions {
   qty?: number;
   /** Project receiving the credits. */
   projectId: string;
+  /** Optional coupon code applied to the checkout. */
   couponCode?: string;
 }
 

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -82,6 +82,13 @@ export interface ProjectDetails {
   billingCycle: BillingCycle;
   subscriptionPlanDetails: SubscriptionPlanDetails;
   prepaidCreditsLink: string;
+  /**
+   * Stripe price ID for the project's prepaid-credits top-up SKU.
+   * Resolved server-side from the plan's per-credit overage cost
+   * (e.g. agent_v4 → 10 USDC → 1M credits price). Only present when the
+   * plan exposes prepaid-credits top-ups; absent for FREE / enterprise.
+   */
+  prepaidCreditsPriceId?: string;
 }
 
 export interface Project extends ProjectListItem {
@@ -90,6 +97,7 @@ export interface Project extends ProjectListItem {
   billingCycle?: BillingCycle;
   subscriptionPlanDetails?: SubscriptionPlanDetails;
   prepaidCreditsLink?: string;
+  prepaidCreditsPriceId?: string;
 }
 
 export type PaymentIntentStatus =

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -109,7 +109,13 @@ export type CheckoutPhase =
 export type PaymentMode = "self_funded" | "sponsored";
 
 export interface CheckoutRequest {
-  plan: string; // 'basic' | 'developer' | 'business' | 'professional'
+  plan: string; // 'developer' | 'business' | 'professional' | 'agent'
+  /**
+   * Ignored for `plan: 'agent'` — the Agent Plan is a one-time invoice,
+   * not a subscription, so period is not meaningful. Callers may still
+   * pass any value for type compatibility; it's dropped before the
+   * backend call.
+   */
   period: "monthly" | "yearly";
   refId: string;
   email?: string;
@@ -121,7 +127,7 @@ export interface CheckoutRequest {
 }
 
 export interface CheckoutInitializeRequest {
-  priceId: string; // OpenPay price ID — resolved internally from plan+period
+  priceId: string; // Stripe price ID — resolved internally from plan+period
   refId: string; // User ID (base58 from walletSignup) or project UUID
   email?: string;
   firstName?: string;
@@ -130,6 +136,12 @@ export interface CheckoutInitializeRequest {
   couponCode?: string;
   paymentMode?: PaymentMode;
   signupWalletAddress?: string;
+  /**
+   * Quantity multiplier for one-time purchases (prepaid credits). Each
+   * unit grants 1,000,000 credits at the backend. Ignored for
+   * subscription plans.
+   */
+  qty?: number;
 }
 
 export interface CheckoutInitializeResponse {
@@ -203,16 +215,38 @@ export interface CheckoutResult {
 export interface AgenticSignupOptions {
   secretKey: Uint8Array;
   userAgent?: string;
-  plan?: string; // 'basic' ($1, default) | 'developer' | 'business' | 'professional'
-  period?: "monthly" | "yearly"; // Only for OpenPay plans, default 'monthly'
-  email?: string; // Only for OpenPay plans
-  firstName?: string; // Only for OpenPay plans
-  lastName?: string; // Only for OpenPay plans
-  couponCode?: string; // Only for OpenPay plans
+  /** 'developer' | 'business' | 'professional' | 'agent' (default). */
+  plan?: string;
+  /**
+   * Only for subscription plans (developer/business/professional).
+   * Ignored for `plan: 'agent'` — the Agent Plan is a one-time invoice.
+   * Default 'monthly'.
+   */
+  period?: "monthly" | "yearly";
+  /** Required for paid plans (developer/business/professional/agent). */
+  email?: string;
+  /** Required for paid plans (developer/business/professional/agent). */
+  firstName?: string;
+  /** Required for paid plans (developer/business/professional/agent). */
+  lastName?: string;
+  /** Optional coupon code for paid plans (developer/business/professional/agent). */
+  couponCode?: string;
+  /**
+   * Pre-authenticated JWT from `walletSignup`. If provided, `refId` is
+   * required. Skips the internal re-authentication round trip so callers
+   * that have already invoked `walletSignup` (e.g. to fetch a pricing
+   * quote) don't force the user to sign the auth message twice.
+   */
+  jwt?: string;
+  /**
+   * `refId` returned by `walletSignup` alongside the JWT. Required when
+   * `jwt` is provided.
+   */
+  refId?: string;
 }
 
 export interface AgenticSignupResult {
-  status: "success" | "existing_project" | "upgraded";
+  status: "success" | "upgraded";
   jwt: string;
   walletAddress: string;
   projectId: string;
@@ -224,6 +258,11 @@ export interface AgenticSignupResult {
 
 export interface SignupQuote {
   plan: string;
+  /**
+   * Echoes the `period` value the caller passed to `getSignupQuote`. Not
+   * meaningful for `plan: 'agent'` (one-time invoice, no period) — the
+   * value is whatever the caller supplied.
+   */
   period: "monthly" | "yearly";
   baseAmountCents: number;
   discountCents: number;
@@ -246,6 +285,34 @@ export interface BuildSponsoredTxResponse {
   transaction: string;
   paymentIntentId: string;
   lastValidBlockHeight: number;
+}
+
+/**
+ * Known prepaid-credits tier keys the backend exposes today. `10_USDC` is
+ * the canonical agent top-up: 10 USDC → 1,000,000 additional credits,
+ * matching the agent plan's signup pricing and `overageCost`. The backend
+ * also exposes `4_USDC` and `5_USDC` tiers but only `10_USDC` is
+ * advertised by the CLI/MCP. The `string & {}` opening keeps the type
+ * future-proof for tiers added later without an SDK patch.
+ */
+export type PrepaidCreditsTier = "10_USDC" | (string & {});
+
+export interface PurchaseCreditsOptions {
+  /** Tier key from `stripe.prepaidCreditsPlans` — default `"10_USDC"`. */
+  tier?: PrepaidCreditsTier;
+  /** Quantity multiplier. Each unit grants 1,000,000 credits. Default 1. */
+  qty?: number;
+  /** Project receiving the credits. */
+  projectId: string;
+  couponCode?: string;
+}
+
+export interface PurchaseCreditsResult {
+  paymentIntentId: string;
+  txSignature: string | null;
+  status: "completed" | "expired" | "failed" | "timeout";
+  amountCents: number;
+  error?: string;
 }
 
 export interface AuthClient {
@@ -341,4 +408,14 @@ export interface AuthClient {
     jwt: string,
     paymentIntentId: string
   ): Promise<CheckoutResult>;
+  /**
+   * Buy additional prepaid credits for an agent-plan project. Agent-only
+   * in this release: pre-flight rejects non-agent projects before
+   * calling `/checkout/initialize` (see `src/auth/purchaseCredits.ts`).
+   */
+  purchaseCredits(
+    secretKey: Uint8Array,
+    jwt: string,
+    options: PurchaseCreditsOptions
+  ): Promise<PurchaseCreditsResult>;
 }


### PR DESCRIPTION
## Summary

- **Replace `basic` plan with `agent` plan** as the default entry plan for SDK signups ($10 one-time, 1,000,000 starting credits). `plan: \"basic\"` is rejected with `Unknown plan: basic. Available: developer, business, professional, agent`.
- **Migrate configs read from `openPay.priceIds` → `stripe.priceIds`** (post-monorepo OpenPay cutover). `fetchOpenPayPriceIds` becomes a deprecated wrapper.
- **Branch on plan name in `resolvePriceId`** for `plan === \"agent\"` to auto-send `?agent=cli` and return the flat `stripe.priceIds.AgentPlan`.
- **Accept optional pre-authenticated `jwt` + `refId`** on `agenticSignup` so CLI/MCP callers (e.g. [core-ai#73](https://github.com/helius-labs/core-ai/pull/73)) can skip a redundant `/wallet-signup`.
- **New `purchaseCredits` flow** for agent-plan prepaid credits top-ups — agent-only in this release with a pre-flight plan check, sponsored-first payment (falls back to self-funded on 5xx), each `qty` unit grants 1M credits.

## Related

- Backend gates: [helius-labs/monorepo PR for sponsored prepaid-credits top-ups](https://github.com/helius-labs/monorepo/pulls?q=is%3Apr+agent-plan-sponsored-topup)
- Downstream CLI/MCP consumer: [core-ai#73](https://github.com/helius-labs/core-ai/pull/73)
- Backend PRs already landed: #14496, #14498, #14567, #14572, #14593, #13970

## Test plan

- [x] `pnpm test` — 436/436 Jest tests pass (new coverage for `fetchDevPortalConfigs`, `fetchStripePriceIds`, `fetchPrepaidCreditsPriceIds`, `purchaseCredits`, agent-plan `resolvePriceId`, pre-auth reuse, basic-rejection)
- [x] `pnpm lint` — 0 errors
- [x] `pnpm format` clean
- [x] `pnpm check-bundle` — all entry points tree-shakable, all module files under size caps
- [ ] End-to-end against dev: sign up with `plan: \"agent\"`, verify 10 USDC charged + 1M starting credits + immediate API usability
- [ ] End-to-end: call `purchaseCredits` on an agent project and confirm +1M credits + sponsored fee payer (requires monorepo M1+M2 to be deployed)

## Breaking changes

- `plan: \"basic\"` is rejected by `agenticSignup`. Backend data for existing basic users is untouched; the SDK just refuses new basic signups. Default plan (empty/undefined) switches from `basic` to `agent`.
- `AgenticSignupResult.status` no longer includes `\"existing_project\"` — the SDK now routes existing-user paid-plan requests through upgrade. CLI callers (like core-ai) should add a pre-signup fast-path if they want recovery UX without a paid upgrade prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)