### PR TITLE
Add getTransfersByAddress RPC method

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Enhanced RPC methods, available only with Helius.
 - [`getTokenAccountsByOwnerV2()`](https://www.helius.dev/docs/api-reference/rpc/http/gettokenaccountsbyownerv2): An enhanced version of `getTokenAccountsByOwner` with cursor-based pagination and `changedSinceSlot` support to incrementally retrieve SPL token accounts owned by a given mint.
 - `getAllTokenAccountsByOwner()`: Auto-paginates all token accounts for a given owner.
 - [`getTransactionsForAddress()`](https://www.helius.dev/docs/rpc/gettransactionsforaddress): Get transaction history for an address with advanced filtering by slot, time, and bidirectional sorting options. Supports both signature-only and full transaction details. Optionally include transactions from associated token accounts.
-- `getTransfersByAddress()`: Get parsed token and native SOL transfer history for an address with filters by mint, time, amount, counterparty, direction, and cursor pagination.
+- [`getTransfersByAddress()`](https://www.helius.dev/docs/rpc/gettransfersbyaddress): Get parsed token and native SOL transfer history for an address with filters by mint, time, amount, counterparty, direction, and cursor pagination.
 
 [**Staking**](https://www.helius.dev/docs/staking/how-to-stake-with-helius-programmatically)
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ import { createHelius } from "helius-sdk";
 ```
 
 ### Migrating to `helius-sdk` 2.0.0
+
 The Helius Node.js SDK has been rewritten from the ground up in version 2.0.0 to use [`@solana/kit` (i.e., Kit)](https://www.npmjs.com/package/@solana/kit) under the hood, replacing the dependency on `@solana/web3.js` versions higher than 1.73.2.
 
 We've gone to great lengths to ensure that the developer experience remains largely the same, with minimal impact on existing code. The API methods and namespaces are designed to be intuitive and an improvement on previous versions, so migrating to the latest version is relatively straightforward. There are a plethora of examples found in the `examples` directory, organized by namespace, to aid in this migration.
@@ -136,7 +137,7 @@ Enhanced RPC methods, available only with Helius.
 - [`getTokenAccountsByOwnerV2()`](https://www.helius.dev/docs/api-reference/rpc/http/gettokenaccountsbyownerv2): An enhanced version of `getTokenAccountsByOwner` with cursor-based pagination and `changedSinceSlot` support to incrementally retrieve SPL token accounts owned by a given mint.
 - `getAllTokenAccountsByOwner()`: Auto-paginates all token accounts for a given owner.
 - [`getTransactionsForAddress()`](https://www.helius.dev/docs/rpc/gettransactionsforaddress): Get transaction history for an address with advanced filtering by slot, time, and bidirectional sorting options. Supports both signature-only and full transaction details. Optionally include transactions from associated token accounts.
-- `getTransfersByAddress()`: Get parsed token and native SOL transfer history for an address with filters by mint, time, amount, counterparty, direction, status, and cursor pagination.
+- `getTransfersByAddress()`: Get parsed token and native SOL transfer history for an address with filters by mint, time, amount, counterparty, direction, and cursor pagination.
 
 [**Staking**](https://www.helius.dev/docs/staking/how-to-stake-with-helius-programmatically)
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ Enhanced RPC methods, available only with Helius.
 - `getAllProgramAccounts()`: Auto-paginates through all program accounts. Use with caution on larger programs.
 - [`getTokenAccountsByOwnerV2()`](https://www.helius.dev/docs/api-reference/rpc/http/gettokenaccountsbyownerv2): An enhanced version of `getTokenAccountsByOwner` with cursor-based pagination and `changedSinceSlot` support to incrementally retrieve SPL token accounts owned by a given mint.
 - `getAllTokenAccountsByOwner()`: Auto-paginates all token accounts for a given owner.
-- [`getTransactionsForAddress()`](https://www.helius.dev/docs/rpc/gettransactionsforaddress): Get transaction history for an address with advanced filtering by slot, time, and bidirectional sorting options. Supports both signature-only and full transaction details. Optionally include transactions from associated token accounts. 
+- [`getTransactionsForAddress()`](https://www.helius.dev/docs/rpc/gettransactionsforaddress): Get transaction history for an address with advanced filtering by slot, time, and bidirectional sorting options. Supports both signature-only and full transaction details. Optionally include transactions from associated token accounts.
+- `getTransfersByAddress()`: Get parsed token and native SOL transfer history for an address with filters by mint, time, amount, counterparty, direction, status, and cursor pagination.
 
 [**Staking**](https://www.helius.dev/docs/staking/how-to-stake-with-helius-programmatically)
 

--- a/examples/helius/getTransfersByAddress.ts
+++ b/examples/helius/getTransfersByAddress.ts
@@ -37,9 +37,6 @@ import { createHelius } from "helius-sdk";
         mint: usdcMint,
         direction: "in",
         limit: 10,
-        filters: {
-          status: "succeeded",
-        },
       },
     ]);
 

--- a/examples/helius/getTransfersByAddress.ts
+++ b/examples/helius/getTransfersByAddress.ts
@@ -1,0 +1,88 @@
+import { createHelius } from "helius-sdk";
+
+(async () => {
+  const apiKey = ""; // From Helius dashboard
+  const helius = createHelius({ apiKey });
+
+  const address = "86xCnPeV69n6t3DnyGvkKobf9FdN2H9oiVDdaMpo2MMY";
+  const usdcMint = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+
+  try {
+    console.log("\nExample 1: Get Recent Transfers");
+    const recent = await helius.getTransfersByAddress([
+      address,
+      {
+        limit: 5,
+        sortOrder: "desc",
+      },
+    ]);
+
+    console.log(`Found ${recent.data.length} transfers`);
+    recent.data.forEach((transfer, i) => {
+      console.log(`${i + 1}. ${transfer.uiAmount} of ${transfer.mint}`);
+      console.log(
+        `   ${transfer.fromUserAccount ?? "mint"} -> ${transfer.toUserAccount ?? "burn"}`
+      );
+      console.log(`   Signature: ${transfer.signature}`);
+    });
+
+    if (recent.paginationToken) {
+      console.log(`\nPagination token: ${recent.paginationToken}`);
+    }
+
+    console.log("\nExample 2: Filter by Mint and Direction");
+    const inboundUsdc = await helius.getTransfersByAddress([
+      address,
+      {
+        mint: usdcMint,
+        direction: "in",
+        limit: 10,
+        filters: {
+          status: "succeeded",
+        },
+      },
+    ]);
+
+    console.log(`Found ${inboundUsdc.data.length} inbound USDC transfers`);
+    inboundUsdc.data.forEach((transfer, i) => {
+      console.log(
+        `${i + 1}. ${transfer.uiAmount} USDC from ${transfer.fromUserAccount}`
+      );
+    });
+
+    console.log("\nExample 3: Filter by Counterparty and Time");
+    const oneDayAgo = Math.floor(Date.now() / 1000) - 24 * 60 * 60;
+    const counterpartyTransfers = await helius.getTransfersByAddress([
+      address,
+      {
+        with: "7hPhaUpydpvm8wtiS3k4LPZKUmivQRs7YQmpE1hFshHx",
+        limit: 10,
+        filters: {
+          blockTime: { gte: oneDayAgo },
+        },
+      },
+    ]);
+
+    console.log(
+      `Found ${counterpartyTransfers.data.length} transfers with counterparty`
+    );
+
+    console.log("\nExample 4: Pagination");
+    const page1 = await helius.getTransfersByAddress([address, { limit: 5 }]);
+
+    console.log(`Page 1: ${page1.data.length} transfers`);
+    if (page1.paginationToken) {
+      const page2 = await helius.getTransfersByAddress([
+        address,
+        {
+          limit: 5,
+          paginationToken: page1.paginationToken,
+        },
+      ]);
+
+      console.log(`Page 2: ${page2.data.length} transfers`);
+    }
+  } catch (error) {
+    console.error("Error running examples:", error);
+  }
+})();

--- a/llms.txt
+++ b/llms.txt
@@ -170,7 +170,6 @@ const transfers = await helius.getTransfersByAddress([
     direction: "out",
     filters: {
       blockTime: { gte: unixTimestamp },
-      status: "succeeded",
     },
   },
 ]);

--- a/llms.txt
+++ b/llms.txt
@@ -52,6 +52,12 @@ const txs = await helius.getTransactionsForAddress([
   "wallet_address",
   { limit: 10, transactionDetails: "full" }
 ]);
+
+// Get parsed token and native SOL transfer history
+const transfers = await helius.getTransfersByAddress([
+  "wallet_address",
+  { limit: 10, direction: "in", mint: "token_mint" }
+]);
 ```
 
 ## Examples Directory
@@ -61,7 +67,7 @@ The `examples/` directory contains working code samples for every method in the 
 ```
 examples/
 ├── helius/das/       # DAS API: getAsset, getAssetsByOwner, searchAssets, etc.
-├── helius/           # RPC V2: getProgramAccountsV2, getTransactionsForAddress, etc.
+├── helius/           # RPC V2: getProgramAccountsV2, getTransactionsForAddress, getTransfersByAddress, etc.
 ├── transactions/     # Helius Sender, smart transactions, sendTransaction
 ├── enhanced/         # Enhanced transaction parsing
 ├── webhooks/         # Webhook CRUD operations
@@ -154,6 +160,19 @@ const page1 = await helius.getTransactionsForAddress(["address", { limit: 100 }]
 const page2 = await helius.getTransactionsForAddress([
   "address",
   { limit: 100, paginationToken: page1.paginationToken }
+]);
+
+// Get parsed token and native SOL transfers with filters
+const transfers = await helius.getTransfersByAddress([
+  "address",
+  {
+    limit: 100,
+    direction: "out",
+    filters: {
+      blockTime: { gte: unixTimestamp },
+      status: "succeeded",
+    },
+  },
 ]);
 
 // Get all program accounts with cursor pagination

--- a/llms.txt
+++ b/llms.txt
@@ -1,3 +1,7 @@
+---
+last_updated: 2026-05-05
+---
+
 # Helius SDK
 
 > The Helius TypeScript SDK for Solana development. Use this SDK when building applications that need to interact with Solana.

--- a/src/rpc/createHelius.eager.ts
+++ b/src/rpc/createHelius.eager.ts
@@ -86,6 +86,10 @@ import {
   GetTransactionsForAddressFn,
   makeGetTransactionsForAddress,
 } from "./methods/getTransactionsForAddress";
+import {
+  GetTransfersByAddressFn,
+  makeGetTransfersByAddress,
+} from "./methods/getTransfersByAddress";
 import type { HeliusRpcOptions } from "./types";
 
 export interface HeliusClientEager {
@@ -111,6 +115,7 @@ export interface HeliusClientEager {
   getTokenAccountsByOwnerV2: GetTokenAccountsByOwnerV2Fn;
   getAllTokenAccountsByOwner: GetAllTokenAccountsByOwnerFn;
   getTransactionsForAddress: GetTransactionsForAddressFn;
+  getTransfersByAddress: GetTransfersByAddressFn;
 
   webhooks: WebhookClient;
 
@@ -183,6 +188,7 @@ export const createHeliusEager = ({
     getTokenAccountsByOwnerV2: makeGetTokenAccountsByOwnerV2(call),
     getAllTokenAccountsByOwner: makeGetAllTokenAccountsByOwner(call),
     getTransactionsForAddress: makeGetTransactionsForAddress(call),
+    getTransfersByAddress: makeGetTransfersByAddress(call),
 
     // Webhooks
     get webhooks() {

--- a/src/rpc/index.ts
+++ b/src/rpc/index.ts
@@ -34,6 +34,7 @@ import type { GetAllProgramAccountsFn } from "./methods/getAllProgramAccounts";
 import type { GetTokenAccountsByOwnerV2Fn } from "./methods/getTokenAccountsByOwnerV2";
 import type { GetAllTokenAccountsByOwnerFn } from "./methods/getAllTokenAccountsByOwner.js";
 import type { GetTransactionsForAddressFn } from "./methods/getTransactionsForAddress";
+import type { GetTransfersByAddressFn } from "./methods/getTransfersByAddress";
 import type { EnhancedTxClientLazy } from "../enhanced";
 import { TxHelpersLazy } from "../transactions";
 import type { ResolvedHeliusRpcApi } from "./heliusRpcApi";
@@ -108,6 +109,8 @@ export type HeliusClient = ResolvedHeliusRpcApi & {
   getAllTokenAccountsByOwner: GetAllTokenAccountsByOwnerFn;
   /** Get transactions for a specific address with rich filtering and pagination. */
   getTransactionsForAddress: GetTransactionsForAddressFn;
+  /** Get parsed token and native SOL transfers for a specific address with rich filtering and pagination. */
+  getTransfersByAddress: GetTransfersByAddressFn;
 
   // ── Webhooks ──────────────────────────────────────────────────────
 
@@ -461,6 +464,17 @@ export const createHelius = ({
         "./methods/getTransactionsForAddress.js"
       );
       return makeGetTransactionsForAddress(call);
+    }
+  );
+
+  defineLazyMethod<HeliusClient, GetTransfersByAddressFn>(
+    client,
+    "getTransfersByAddress",
+    async () => {
+      const { makeGetTransfersByAddress } = await import(
+        "./methods/getTransfersByAddress.js"
+      );
+      return makeGetTransfersByAddress(call);
     }
   );
 

--- a/src/rpc/methods/getTransfersByAddress.ts
+++ b/src/rpc/methods/getTransfersByAddress.ts
@@ -1,0 +1,17 @@
+import type {
+  GetTransfersByAddressConfig,
+  GetTransfersByAddressResult,
+} from "../../types";
+import type { RpcCaller } from "../caller";
+
+export type GetTransfersByAddressFn = (
+  params: [string, GetTransfersByAddressConfig?]
+) => Promise<GetTransfersByAddressResult>;
+
+export const makeGetTransfersByAddress =
+  (call: RpcCaller): GetTransfersByAddressFn =>
+  (params) =>
+    call<[string, GetTransfersByAddressConfig?], GetTransfersByAddressResult>(
+      "getTransfersByAddress",
+      params
+    );

--- a/src/rpc/methods/tests/getTransfersByAddress.test.ts
+++ b/src/rpc/methods/tests/getTransfersByAddress.test.ts
@@ -65,7 +65,6 @@ describe("getTransfersByAddress Tests", () => {
           amount: { gte: 1_000_000 },
           blockTime: { gte: 1736159000 },
           slot: { lte: 315073428 },
-          status: "succeeded",
         },
       },
     ]);

--- a/src/rpc/methods/tests/getTransfersByAddress.test.ts
+++ b/src/rpc/methods/tests/getTransfersByAddress.test.ts
@@ -1,0 +1,115 @@
+import { GetTransfersByAddressResult } from "../../../types";
+import { createHeliusEager as createHelius } from "../../createHelius.eager";
+
+const transportMock = jest.fn();
+
+jest.mock("@solana/kit", () => ({
+  createSolanaRpcApi: jest.fn().mockReturnValue({}),
+  DEFAULT_RPC_CONFIG: {},
+  createDefaultRpcTransport: jest.fn(() => transportMock),
+  createRpc: jest.fn().mockReturnValue({}),
+}));
+
+describe("getTransfersByAddress Tests", () => {
+  let rpc: ReturnType<typeof createHelius>;
+  const address = "86xCnPeV69n6t3DnyGvkKobf9FdN2H9oiVDdaMpo2MMY";
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    transportMock.mockReset();
+    rpc = createHelius({ apiKey: "test-key" });
+  });
+
+  it("Fetches transfers with config (mint/direction/filters/pagination)", async () => {
+    const mockResponse: GetTransfersByAddressResult = {
+      data: [
+        {
+          signature:
+            "5GEX7Q3X5Q8yJGbKYoR7mtzQmG8tpoEwzjPgqVmn3y5xg3yKwqXcDdN5YVcc9V6vA4TuH5iM6FHRVhTxvz4AX2zG",
+          slot: 315073428,
+          blockTime: 1736159420,
+          type: "transfer",
+          fromUserAccount: "7hPhaUpydpvm8wtiS3k4LPZKUmivQRs7YQmpE1hFshHx",
+          toUserAccount: address,
+          fromTokenAccount: "HcvK3EJ74iM9g11cUgsaPvLSrhCvCwcrWxBNd87LsC1x",
+          toTokenAccount: "CBcYniR9G9CN3zGMnwNE4SWbqkYWvCFVreEob9xHnQCY",
+          mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+          amount: "2500000",
+          decimals: 6,
+          uiAmount: "2.5",
+          confirmationStatus: "finalized",
+          transactionIdx: 35,
+          instructionIdx: 1,
+          innerInstructionIdx: 0,
+        },
+      ],
+      paginationToken: "315073428:35:1:0",
+    };
+
+    transportMock.mockResolvedValue({
+      jsonrpc: "2.0",
+      id: "1",
+      result: mockResponse,
+    });
+
+    const result = await rpc.getTransfersByAddress([
+      address,
+      {
+        with: "7hPhaUpydpvm8wtiS3k4LPZKUmivQRs7YQmpE1hFshHx",
+        direction: "in",
+        mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+        solMode: "merged",
+        limit: 50,
+        sortOrder: "desc",
+        filters: {
+          amount: { gte: 1_000_000 },
+          blockTime: { gte: 1736159000 },
+          slot: { lte: 315073428 },
+          status: "succeeded",
+        },
+      },
+    ]);
+
+    expect(result).toEqual(mockResponse);
+    expect(transportMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          method: "getTransfersByAddress",
+          params: [
+            address,
+            expect.objectContaining({
+              direction: "in",
+              limit: 50,
+              filters: expect.objectContaining({
+                amount: { gte: 1_000_000 },
+              }),
+            }),
+          ],
+        }),
+      })
+    );
+  });
+
+  it("Handles RPC errors", async () => {
+    transportMock.mockResolvedValue({
+      jsonrpc: "2.0",
+      id: "1",
+      error: { code: -32602, message: "Invalid params" },
+    });
+
+    await expect(
+      rpc.getTransfersByAddress([
+        address,
+        { limit: -1 }, // Invalid on purpose
+      ])
+    ).rejects.toThrow(/Invalid params/);
+
+    expect(transportMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          method: "getTransfersByAddress",
+        }),
+      })
+    );
+  });
+});

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -364,3 +364,110 @@ export type GetTransactionsForAddressResultFull = {
   data: ReadonlyArray<TransactionForAddressFull>;
   paginationToken: string | null;
 };
+
+// ── getTransfersByAddress ───────────────────────────────────────────
+
+/** Numeric comparison filter used by transfer amount, blockTime, and slot filters. */
+export type TransferComparisonFilter = {
+  /** Greater than */
+  gt?: number;
+  /** Greater than or equal to */
+  gte?: number;
+  /** Less than */
+  lt?: number;
+  /** Less than or equal to */
+  lte?: number;
+};
+
+/** Configuration for `getTransfersByAddress` transfer queries. */
+export type GetTransfersByAddressConfig = {
+  /** Filter by counterparty address. Returns only transfers to or from this address. */
+  with?: string;
+  /** Filter by transfer direction relative to the queried address. */
+  direction?: "in" | "out" | "any";
+  /** Filter by token mint address. Use native SOL or WSOL mint addresses for SOL filtering. */
+  mint?: string;
+  /** SOL/WSOL display mode. */
+  solMode?: "merged" | "separate";
+  /** Additional filters for amount, block time, slot, and status. */
+  filters?: {
+    /** Filter by raw transfer amount, not UI amount. */
+    amount?: TransferComparisonFilter;
+    /** Filter by block timestamp in Unix seconds. */
+    blockTime?: TransferComparisonFilter;
+    /** Filter by slot number. */
+    slot?: TransferComparisonFilter;
+    /** Transaction status. */
+    status?: "succeeded" | "failed" | "any";
+  };
+  /** Max transfers per page. */
+  limit?: number;
+  /** Pagination token from a previous response. `null` when no more pages. */
+  paginationToken?: string | null;
+  /** Data commitment level. */
+  commitment?: "finalized" | "confirmed";
+  /** Result ordering. */
+  sortOrder?: "asc" | "desc";
+};
+
+/** Request tuple for `getTransfersByAddress`: `[address, config?]`. */
+export type GetTransfersByAddressRequest = [
+  string,
+  GetTransfersByAddressConfig?,
+];
+
+/** Parsed, human-readable token or native SOL transfer record. */
+export type TokenTransfer = {
+  /** Base58-encoded transaction signature. */
+  signature: string;
+  /** Slot number containing the transaction. */
+  slot: number;
+  /** Unix timestamp in seconds for the block. */
+  blockTime: number;
+  /** Parsed transfer type. */
+  type:
+    | "transfer"
+    | "transferFee"
+    | "mint"
+    | "burn"
+    | "wrap"
+    | "unwrap"
+    | "changeAccountOwner"
+    | "withdrawWithheldFee";
+  /** Wallet address that sent the tokens, or `null` when no sender exists. */
+  fromUserAccount: string | null;
+  /** Wallet address that received the tokens, or `null` when no recipient exists. */
+  toUserAccount: string | null;
+  /** Source token account. Omitted when not applicable, such as native SOL transfers. */
+  fromTokenAccount?: string;
+  /** Destination token account. Omitted when not applicable, such as native SOL transfers. */
+  toTokenAccount?: string;
+  /** Token mint address. */
+  mint: string;
+  /** Raw transfer amount as a string to preserve precision. */
+  amount: string;
+  /** Transfer fee withheld by the Token-2022 transfer-fee extension. */
+  feeAmount?: string;
+  /** Token account associated with the withheld fee. */
+  feeAccount?: string;
+  /** Token decimals. Native SOL uses 9. */
+  decimals: number;
+  /** Human-readable amount. */
+  uiAmount: string;
+  /** Human-readable fee amount. Present only when `feeAmount` is present. */
+  feeUiAmount?: string;
+  /** Confirmation status. */
+  confirmationStatus: "finalized" | "confirmed";
+  /** Index of the transaction within the block. */
+  transactionIdx: number;
+  /** Index of the instruction within the transaction. */
+  instructionIdx: number;
+  /** Index within inner instructions. `0` when the transfer is top-level. */
+  innerInstructionIdx: number;
+};
+
+/** Paginated result with parsed transfer data. */
+export type GetTransfersByAddressResult = {
+  data: ReadonlyArray<TokenTransfer>;
+  paginationToken: string | null;
+};

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -389,7 +389,7 @@ export type GetTransfersByAddressConfig = {
   mint?: string;
   /** SOL/WSOL display mode. */
   solMode?: "merged" | "separate";
-  /** Additional filters for amount, block time, slot, and status. */
+  /** Additional filters for amount, block time, and slot. */
   filters?: {
     /** Filter by raw transfer amount, not UI amount. */
     amount?: TransferComparisonFilter;
@@ -397,8 +397,6 @@ export type GetTransfersByAddressConfig = {
     blockTime?: TransferComparisonFilter;
     /** Filter by slot number. */
     slot?: TransferComparisonFilter;
-    /** Transaction status. */
-    status?: "succeeded" | "failed" | "any";
   };
   /** Max transfers per page. */
   limit?: number;
@@ -427,12 +425,11 @@ export type TokenTransfer = {
   /** Parsed transfer type. */
   type:
     | "transfer"
-    | "transferFee"
     | "mint"
     | "burn"
     | "wrap"
     | "unwrap"
-    | "changeAccountOwner"
+    | "changeOwner"
     | "withdrawWithheldFee";
   /** Wallet address that sent the tokens, or `null` when no sender exists. */
   fromUserAccount: string | null;


### PR DESCRIPTION
## Summary
- add typed getTransfersByAddress RPC wrapper to eager and lazy clients
- add transfer request/response types aligned with current docs
- add example, README/llms docs, and focused method tests

## Verification
- pnpm exec jest --coverage=false getTransfersByAddress
- pnpm exec jest --runInBand
- git diff --check