### PR TITLE
chore(ci): Bump Bundlemon Cap for `rpc/index.js` to 2.6kb

### DIFF
--- a/bundlemon.config.js
+++ b/bundlemon.config.js
@@ -28,8 +28,11 @@ export default {
       maxSize: '1kb',
     },
     {
+      // Lazy-loaded HeliusClient entry point: every new defineLazyMethod
+      // adds ~50B gzipped. Bumped after getTransfersByAddress (#313) put
+      // the file at 2.55KB.
       path: 'dist/esm/rpc/index.js',
-      maxSize: '2.52kb',
+      maxSize: '2.6kb',
     },
     {
       // Aggregator for every checkout primitive: resolvePriceId,


### PR DESCRIPTION
This PR bumps the bundlemon cap on `dist/esm/rpc/index.js` from 2.52KB to 2.6KB to fix CI on `main`