### PR TITLE
chore(security): Pin pnpm SHA and Clean Up Workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9
           run_install: false
 
       - name: Cache dependencies
@@ -55,7 +54,6 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9
           run_install: false
 
       - name: Cache dependencies
@@ -93,7 +91,6 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9
           run_install: false
 
       - name: Cache dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,6 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9
           run_install: false
 
       - name: Cache dependencies
@@ -63,7 +62,6 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9
           run_install: false
 
       - name: Cache dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,6 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9
           run_install: false
 
       - name: Cache dependencies

--- a/package.json
+++ b/package.json
@@ -168,5 +168,6 @@
     "tsx": "^4.20.3",
     "typedoc": "^0.28.17",
     "typescript": "^5.8.3"
-  }
+  },
+  "packageManager": "pnpm@10.26.0+sha512.3b3f6c725ebe712506c0ab1ad4133cf86b1f4b687effce62a9b38b4d72e3954242e643190fc51fa1642949c735f403debd44f5cb0edd657abe63a8b6a7e1e402"
 }


### PR DESCRIPTION
This PR hardens the supply chain by pinning the exact pnpm binary every install uses by adding `packageManager: "pnpm@10.26.0+sha512.<hash>"` to our `package.json`. Node's corepack verifies the SHA512 of the pnpm tarball before every command, so a tampered binary or compromised registry response gets caught at install time

We also drop the explicit `version: 9` from every `pnpm/action-setup@v4` step (i.e., 6 occurrences across `ci.yml`, `publish.yml`, `release.yml`). Without that input, the action reads the pinned version from `packageManager`, so CI uses the exact same pnpm 10.26.0 binary as local dev and the lockfile generator

This fixes a silent drift: CI was running pnpm 9 while the local `pnpm-lock.yaml` (i.e., `lockfileVersion: '9.0'`) was generated with pnpm 10. The lockfile format is compatible between the two, but the resolver behavior isn't identical; pinning to 10.26.0 everywhere removes that as a source of "works on my machine"