### PR TITLE
docs(security): Add `SECURITY.md`

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+# Security Policy
+
+To report a suspected vulnerability in `helius-sdk`, email **[security@helius.xyz](mailto:security@helius.xyz)**.
+
+Please do not open public GitHub issues, discussions, or pull requests for security reports; that information would be visible before a fix ships.


### PR DESCRIPTION
This PR adds a minimal `SECURITY.md` at the repo root; the SDK-side complement to the `security.txt` files on customer-facing properties (i.e., orbmarkets.io, helius.xyz)