### PR TITLE
fix(auth): Circular Dep and Stale tsc Errors

### DIFF
--- a/src/auth/checkout.ts
+++ b/src/auth/checkout.ts
@@ -131,21 +131,6 @@ export async function getPaymentIntent(
   );
 }
 
-export async function getPaymentStatus(
-  jwt: string,
-  paymentIntentId: string,
-  userAgent?: string
-): Promise<CheckoutStatusResponse> {
-  return authRequest<CheckoutStatusResponse>(
-    `/checkout/${paymentIntentId}/status`,
-    {
-      method: "GET",
-      headers: { Authorization: `Bearer ${jwt}` },
-    },
-    userAgent
-  );
-}
-
 export async function pollCheckoutCompletion(
   jwt: string,
   paymentIntentId: string,

--- a/src/auth/client.ts
+++ b/src/auth/client.ts
@@ -15,8 +15,8 @@ import {
   initializeCheckout,
   getCheckoutPreview,
   getPaymentIntent,
-  getPaymentStatus,
 } from "./checkout";
+import { getPaymentStatus } from "./getPaymentStatus";
 import { purchaseCredits, purchaseCreditsAndPay } from "./purchaseCredits";
 import { upgradePlan, upgradePlanAndPay } from "./upgradePlan";
 import { payRenewal, payRenewalAndPay } from "./payRenewal";

--- a/src/auth/getPaymentStatus.ts
+++ b/src/auth/getPaymentStatus.ts
@@ -1,0 +1,17 @@
+import type { CheckoutStatusResponse } from "./types";
+import { authRequest } from "./utils";
+
+export async function getPaymentStatus(
+  jwt: string,
+  paymentIntentId: string,
+  userAgent?: string
+): Promise<CheckoutStatusResponse> {
+  return authRequest<CheckoutStatusResponse>(
+    `/checkout/${paymentIntentId}/status`,
+    {
+      method: "GET",
+      headers: { Authorization: `Bearer ${jwt}` },
+    },
+    userAgent
+  );
+}

--- a/src/auth/pollPayment.ts
+++ b/src/auth/pollPayment.ts
@@ -2,7 +2,7 @@ import {
   CHECKOUT_POLL_INTERVAL_MS,
   CHECKOUT_POLL_TIMEOUT_MS,
 } from "./constants";
-import { getPaymentStatus } from "./checkout";
+import { getPaymentStatus } from "./getPaymentStatus";
 import { getHttpStatus } from "./getHttpStatus";
 import { sleep } from "./utils";
 import type { CheckoutStatusResponse } from "./types";

--- a/src/auth/tests/buildTokenTransfer.test.ts
+++ b/src/auth/tests/buildTokenTransfer.test.ts
@@ -1,3 +1,4 @@
+import type { Address } from "@solana/kit";
 import {
   buildAndSendTokenTransfer,
   type TokenTransferParams,
@@ -67,7 +68,7 @@ describe("buildAndSendTokenTransfer", () => {
     const params: TokenTransferParams = {
       secretKey: mockSecretKey,
       recipientAddress: "RecipientAddress111111111111111111",
-      mintAddress: "MintAddress1111111111111111111111" as `${string}`,
+      mintAddress: "MintAddress1111111111111111111111" as Address,
       amount: 1_000_000n,
     };
 
@@ -88,7 +89,7 @@ describe("buildAndSendTokenTransfer", () => {
     const params: TokenTransferParams = {
       secretKey: mockSecretKey,
       recipientAddress: "RecipientAddress111111111111111111",
-      mintAddress: "MintAddress1111111111111111111111" as `${string}`,
+      mintAddress: "MintAddress1111111111111111111111" as Address,
       amount: 500_000n,
       additionalInstructions: [memoIx as never],
     };
@@ -105,7 +106,7 @@ describe("buildAndSendTokenTransfer", () => {
     const params: TokenTransferParams = {
       secretKey: mockSecretKey,
       recipientAddress: "RecipientAddress111111111111111111",
-      mintAddress: "MintAddress1111111111111111111111" as `${string}`,
+      mintAddress: "MintAddress1111111111111111111111" as Address,
       amount: 1_000_000n,
       additionalInstructions: [],
     };

--- a/src/auth/tests/checkBalances.test.ts
+++ b/src/auth/tests/checkBalances.test.ts
@@ -10,7 +10,7 @@ jest.mock("@solana/kit", () => {
   const actual = jest.requireActual("@solana/kit");
   return {
     ...actual,
-    createSolanaRpc: (...args: any[]) => mockCreateSolanaRpc(...args),
+    createSolanaRpc: mockCreateSolanaRpc,
   };
 });
 

--- a/src/auth/tests/checkout.test.ts
+++ b/src/auth/tests/checkout.test.ts
@@ -3,9 +3,9 @@ import {
   pollCheckoutCompletion,
   getCheckoutPreview,
   getPaymentIntent,
-  getPaymentStatus,
   resolvePriceId,
 } from "../checkout";
+import { getPaymentStatus } from "../getPaymentStatus";
 import { authRequest } from "../utils";
 import { fetchStripePriceIds } from "../devPortalConfigs";
 

--- a/src/auth/tests/payRenewal.test.ts
+++ b/src/auth/tests/payRenewal.test.ts
@@ -1,5 +1,7 @@
 jest.mock("../checkout", () => ({
   getPaymentIntent: jest.fn(),
+}));
+jest.mock("../getPaymentStatus", () => ({
   getPaymentStatus: jest.fn(),
 }));
 jest.mock("../payPaymentLink", () => ({
@@ -7,7 +9,8 @@ jest.mock("../payPaymentLink", () => ({
 }));
 
 import { payRenewal, payRenewalAndPay } from "../payRenewal";
-import { getPaymentIntent, getPaymentStatus } from "../checkout";
+import { getPaymentIntent } from "../checkout";
+import { getPaymentStatus } from "../getPaymentStatus";
 import { payPaymentLink } from "../payPaymentLink";
 
 const mockGetPaymentIntent = getPaymentIntent as jest.MockedFunction<

--- a/src/auth/tests/pollPayment.test.ts
+++ b/src/auth/tests/pollPayment.test.ts
@@ -1,7 +1,7 @@
 import { pollUntilTerminal } from "../pollPayment";
-import { getPaymentStatus } from "../checkout";
+import { getPaymentStatus } from "../getPaymentStatus";
 
-jest.mock("../checkout");
+jest.mock("../getPaymentStatus");
 
 jest.mock("../constants", () => ({
   ...jest.requireActual("../constants"),

--- a/src/auth/tests/purchaseCredits.test.ts
+++ b/src/auth/tests/purchaseCredits.test.ts
@@ -4,6 +4,8 @@ jest.mock("../checkout", () => ({
   resolvePriceId: jest.fn(),
   initializeCheckout: jest.fn(),
   getCheckoutPreview: jest.fn(),
+}));
+jest.mock("../getPaymentStatus", () => ({
   getPaymentStatus: jest.fn(),
 }));
 jest.mock("../payPaymentLink", () => ({
@@ -15,7 +17,8 @@ jest.mock("../payPaymentLink", () => ({
 import { purchaseCredits, purchaseCreditsAndPay } from "../purchaseCredits";
 import { listProjects } from "../listProjects";
 import { getProject } from "../getProject";
-import { initializeCheckout, getPaymentStatus } from "../checkout";
+import { initializeCheckout } from "../checkout";
+import { getPaymentStatus } from "../getPaymentStatus";
 import { payPaymentLink } from "../payPaymentLink";
 
 const mockListProjects = listProjects as jest.MockedFunction<

--- a/src/auth/tests/signup.test.ts
+++ b/src/auth/tests/signup.test.ts
@@ -37,6 +37,9 @@ jest.mock("../checkout", () => ({
   resolvePriceId: jest.fn().mockResolvedValue("price_agent_1_usdc"),
   getCheckoutPreview: jest.fn(),
   initializeCheckout: jest.fn(),
+}));
+
+jest.mock("../getPaymentStatus", () => ({
   getPaymentStatus: jest.fn(),
 }));
 
@@ -49,11 +52,8 @@ import { signupAndPay } from "../signupAndPay";
 import { listProjects } from "../listProjects";
 import { getProject } from "../getProject";
 import { createApiKey } from "../createApiKey";
-import {
-  getCheckoutPreview,
-  initializeCheckout,
-  getPaymentStatus,
-} from "../checkout";
+import { getCheckoutPreview, initializeCheckout } from "../checkout";
+import { getPaymentStatus } from "../getPaymentStatus";
 import { payPaymentLink } from "../payPaymentLink";
 
 const mockListProjects = listProjects as jest.MockedFunction<

--- a/src/auth/tests/upgradePlan.test.ts
+++ b/src/auth/tests/upgradePlan.test.ts
@@ -2,6 +2,8 @@ jest.mock("../checkout", () => ({
   resolvePriceId: jest.fn().mockResolvedValue("price_business_monthly"),
   initializeCheckout: jest.fn(),
   getCheckoutPreview: jest.fn(),
+}));
+jest.mock("../getPaymentStatus", () => ({
   getPaymentStatus: jest.fn(),
 }));
 jest.mock("../payPaymentLink", () => ({
@@ -9,11 +11,8 @@ jest.mock("../payPaymentLink", () => ({
 }));
 
 import { upgradePlan, upgradePlanAndPay } from "../upgradePlan";
-import {
-  initializeCheckout,
-  getCheckoutPreview,
-  getPaymentStatus,
-} from "../checkout";
+import { initializeCheckout, getCheckoutPreview } from "../checkout";
+import { getPaymentStatus } from "../getPaymentStatus";
 import { payPaymentLink } from "../payPaymentLink";
 
 const mockInitializeCheckout = initializeCheckout as jest.MockedFunction<

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -512,8 +512,7 @@ export interface PurchaseCreditsLinkOptions {
   paymentHost?: string;
 }
 
-export interface PurchaseCreditsAndPayOptions
-  extends PurchaseCreditsLinkOptions {
+export interface PurchaseCreditsAndPayOptions extends PurchaseCreditsLinkOptions {
   secretKey: Uint8Array;
 }
 

--- a/src/rpc/index.ts
+++ b/src/rpc/index.ts
@@ -308,9 +308,8 @@ export const createHelius = ({
     client,
     "getAssetProofBatch",
     async () => {
-      const { makeGetAssetProofBatch } = await import(
-        "./methods/getAssetProofBatch.js"
-      );
+      const { makeGetAssetProofBatch } =
+        await import("./methods/getAssetProofBatch.js");
       return makeGetAssetProofBatch(call);
     }
   );
@@ -319,9 +318,8 @@ export const createHelius = ({
     client,
     "getAssetsByAuthority",
     async () => {
-      const { makeGetAssetsByAuthority } = await import(
-        "./methods/getAssetsByAuthority.js"
-      );
+      const { makeGetAssetsByAuthority } =
+        await import("./methods/getAssetsByAuthority.js");
       return makeGetAssetsByAuthority(call);
     }
   );
@@ -330,9 +328,8 @@ export const createHelius = ({
     client,
     "getAssetsByCreator",
     async () => {
-      const { makeGetAssetsByCreator } = await import(
-        "./methods/getAssetsByCreator.js"
-      );
+      const { makeGetAssetsByCreator } =
+        await import("./methods/getAssetsByCreator.js");
       return makeGetAssetsByCreator(call);
     }
   );
@@ -341,9 +338,8 @@ export const createHelius = ({
     client,
     "getAssetsByGroup",
     async () => {
-      const { makeGetAssetsByGroup } = await import(
-        "./methods/getAssetsByGroup.js"
-      );
+      const { makeGetAssetsByGroup } =
+        await import("./methods/getAssetsByGroup.js");
       return makeGetAssetsByGroup(call);
     }
   );
@@ -352,9 +348,8 @@ export const createHelius = ({
     client,
     "getAssetsByOwner",
     async () => {
-      const { makeGetAssetsByOwner } = await import(
-        "./methods/getAssetsByOwner.js"
-      );
+      const { makeGetAssetsByOwner } =
+        await import("./methods/getAssetsByOwner.js");
       return makeGetAssetsByOwner(call);
     }
   );
@@ -363,9 +358,8 @@ export const createHelius = ({
     client,
     "getNftEditions",
     async () => {
-      const { makeGetNftEditions } = await import(
-        "./methods/getNftEditions.js"
-      );
+      const { makeGetNftEditions } =
+        await import("./methods/getNftEditions.js");
       return makeGetNftEditions(call);
     }
   );
@@ -374,9 +368,8 @@ export const createHelius = ({
     client,
     "getSignaturesForAsset",
     async () => {
-      const { makeGetSignaturesForAsset } = await import(
-        "./methods/getSignaturesForAsset.js"
-      );
+      const { makeGetSignaturesForAsset } =
+        await import("./methods/getSignaturesForAsset.js");
       return makeGetSignaturesForAsset(call);
     }
   );
@@ -385,9 +378,8 @@ export const createHelius = ({
     client,
     "getTokenAccounts",
     async () => {
-      const { makeGetTokenAccounts } = await import(
-        "./methods/getTokenAccounts.js"
-      );
+      const { makeGetTokenAccounts } =
+        await import("./methods/getTokenAccounts.js");
       return makeGetTokenAccounts(call);
     }
   );
@@ -405,9 +397,8 @@ export const createHelius = ({
     client,
     "getPriorityFeeEstimate",
     async () => {
-      const { makeGetPriorityFeeEstimate } = await import(
-        "./methods/getPriorityFeeEstimate.js"
-      );
+      const { makeGetPriorityFeeEstimate } =
+        await import("./methods/getPriorityFeeEstimate.js");
       return makeGetPriorityFeeEstimate(call);
     }
   );
@@ -416,9 +407,8 @@ export const createHelius = ({
     client,
     "getProgramAccountsV2",
     async () => {
-      const { makeGetProgramAccountsV2 } = await import(
-        "./methods/getProgramAccountsV2.js"
-      );
+      const { makeGetProgramAccountsV2 } =
+        await import("./methods/getProgramAccountsV2.js");
       return makeGetProgramAccountsV2(call);
     }
   );
@@ -427,9 +417,8 @@ export const createHelius = ({
     client,
     "getAllProgramAccounts",
     async () => {
-      const { makeGetAllProgramAccounts } = await import(
-        "./methods/getAllProgramAccounts.js"
-      );
+      const { makeGetAllProgramAccounts } =
+        await import("./methods/getAllProgramAccounts.js");
       return makeGetAllProgramAccounts(call);
     }
   );
@@ -438,9 +427,8 @@ export const createHelius = ({
     client,
     "getTokenAccountsByOwnerV2",
     async () => {
-      const { makeGetTokenAccountsByOwnerV2 } = await import(
-        "./methods/getTokenAccountsByOwnerV2.js"
-      );
+      const { makeGetTokenAccountsByOwnerV2 } =
+        await import("./methods/getTokenAccountsByOwnerV2.js");
       return makeGetTokenAccountsByOwnerV2(call);
     }
   );
@@ -449,9 +437,8 @@ export const createHelius = ({
     client,
     "getAllTokenAccountsByOwner",
     async () => {
-      const { makeGetAllTokenAccountsByOwner } = await import(
-        "./methods/getAllTokenAccountsByOwner.js"
-      );
+      const { makeGetAllTokenAccountsByOwner } =
+        await import("./methods/getAllTokenAccountsByOwner.js");
       return makeGetAllTokenAccountsByOwner(call);
     }
   );
@@ -460,9 +447,8 @@ export const createHelius = ({
     client,
     "getTransactionsForAddress",
     async () => {
-      const { makeGetTransactionsForAddress } = await import(
-        "./methods/getTransactionsForAddress.js"
-      );
+      const { makeGetTransactionsForAddress } =
+        await import("./methods/getTransactionsForAddress.js");
       return makeGetTransactionsForAddress(call);
     }
   );
@@ -471,9 +457,8 @@ export const createHelius = ({
     client,
     "getTransfersByAddress",
     async () => {
-      const { makeGetTransfersByAddress } = await import(
-        "./methods/getTransfersByAddress.js"
-      );
+      const { makeGetTransfersByAddress } =
+        await import("./methods/getTransfersByAddress.js");
       return makeGetTransfersByAddress(call);
     }
   );
@@ -510,9 +495,8 @@ export const createHelius = ({
 
   defineLazyNamespace<HeliusClient, TxHelpersLazy>(client, "tx", async () => {
     const { makeTxHelpersLazy } = await import("../transactions");
-    const { makeGetPriorityFeeEstimate } = await import(
-      "./methods/getPriorityFeeEstimate.js"
-    );
+    const { makeGetPriorityFeeEstimate } =
+      await import("./methods/getPriorityFeeEstimate.js");
     const getPriorityFeeEstimate = makeGetPriorityFeeEstimate(call);
 
     return makeTxHelpersLazy(

--- a/src/zk/client.ts
+++ b/src/zk/client.ts
@@ -97,9 +97,8 @@ export const makeZkClientLazy = (call: RpcCaller): ZkClientLazy => {
     obj,
     "getCompressedAccount",
     async () => {
-      const { makeGetCompressedAccount } = await import(
-        "./methods/getCompressedAccount"
-      );
+      const { makeGetCompressedAccount } =
+        await import("./methods/getCompressedAccount");
       return makeGetCompressedAccount(call);
     }
   );
@@ -108,24 +107,21 @@ export const makeZkClientLazy = (call: RpcCaller): ZkClientLazy => {
     obj,
     "getCompressedAccountProof",
     async () => {
-      const { makeGetCompressedAccountProof } = await import(
-        "./methods/getCompressedAccountProof"
-      );
+      const { makeGetCompressedAccountProof } =
+        await import("./methods/getCompressedAccountProof");
       return makeGetCompressedAccountProof(call);
     }
   );
 
   defineLazyMethod(obj, "getCompressedAccountsByOwner", async () => {
-    const { makeGetCompressedAccountsByOwner } = await import(
-      "./methods/getCompressedAccountsByOwner"
-    );
+    const { makeGetCompressedAccountsByOwner } =
+      await import("./methods/getCompressedAccountsByOwner");
     return makeGetCompressedAccountsByOwner(call);
   });
 
   defineLazyMethod(obj, "getCompressedBalance", async () => {
-    const { makeGetCompressedBalance } = await import(
-      "./methods/getCompressedBalance"
-    );
+    const { makeGetCompressedBalance } =
+      await import("./methods/getCompressedBalance");
     return makeGetCompressedBalance(call);
   });
 
@@ -133,9 +129,8 @@ export const makeZkClientLazy = (call: RpcCaller): ZkClientLazy => {
     obj,
     "getCompressedBalanceByOwner",
     async () => {
-      const { makeGetCompressedBalanceByOwner } = await import(
-        "./methods/getCompressedBalanceByOwner"
-      );
+      const { makeGetCompressedBalanceByOwner } =
+        await import("./methods/getCompressedBalanceByOwner");
       return makeGetCompressedBalanceByOwner(call);
     }
   );
@@ -144,9 +139,8 @@ export const makeZkClientLazy = (call: RpcCaller): ZkClientLazy => {
     obj,
     "getCompressedMintTokenHolders",
     async () => {
-      const { makeGetCompressedMintTokenHolders } = await import(
-        "./methods/getCompressedMintTokenHolders"
-      );
+      const { makeGetCompressedMintTokenHolders } =
+        await import("./methods/getCompressedMintTokenHolders");
       return makeGetCompressedMintTokenHolders(call);
     }
   );
@@ -155,9 +149,8 @@ export const makeZkClientLazy = (call: RpcCaller): ZkClientLazy => {
     obj,
     "getCompressedTokenAccountBalance",
     async () => {
-      const { makeGetCompressedTokenAccountBalance } = await import(
-        "./methods/getCompressedTokenAccountBalance"
-      );
+      const { makeGetCompressedTokenAccountBalance } =
+        await import("./methods/getCompressedTokenAccountBalance");
       return makeGetCompressedTokenAccountBalance(call);
     }
   );
@@ -166,9 +159,8 @@ export const makeZkClientLazy = (call: RpcCaller): ZkClientLazy => {
     obj,
     "getCompressedTokenAccountsByDelegate",
     async () => {
-      const { makeGetCompressedTokenAccountsByDelegate } = await import(
-        "./methods/getCompressedTokenAccountsByDelegate"
-      );
+      const { makeGetCompressedTokenAccountsByDelegate } =
+        await import("./methods/getCompressedTokenAccountsByDelegate");
       return makeGetCompressedTokenAccountsByDelegate(call);
     }
   );
@@ -177,9 +169,8 @@ export const makeZkClientLazy = (call: RpcCaller): ZkClientLazy => {
     obj,
     "getCompressedTokenAccountsByOwner",
     async () => {
-      const { makeGetCompressedTokenAccountsByOwner } = await import(
-        "./methods/getCompressedTokenAccountsByOwner"
-      );
+      const { makeGetCompressedTokenAccountsByOwner } =
+        await import("./methods/getCompressedTokenAccountsByOwner");
       return makeGetCompressedTokenAccountsByOwner(call);
     }
   );
@@ -188,9 +179,8 @@ export const makeZkClientLazy = (call: RpcCaller): ZkClientLazy => {
     obj,
     "getCompressedTokenBalancesByOwner",
     async () => {
-      const { makeGetCompressedTokenBalancesByOwner } = await import(
-        "./methods/getCompressedTokenBalancesByOwner"
-      );
+      const { makeGetCompressedTokenBalancesByOwner } =
+        await import("./methods/getCompressedTokenBalancesByOwner");
       return makeGetCompressedTokenBalancesByOwner(call);
     }
   );
@@ -199,9 +189,8 @@ export const makeZkClientLazy = (call: RpcCaller): ZkClientLazy => {
     obj,
     "getCompressedTokenBalancesByOwnerV2",
     async () => {
-      const { makeGetCompressedTokenBalancesByOwnerV2 } = await import(
-        "./methods/getCompressedTokenBalancesByOwnerV2"
-      );
+      const { makeGetCompressedTokenBalancesByOwnerV2 } =
+        await import("./methods/getCompressedTokenBalancesByOwnerV2");
       return makeGetCompressedTokenBalancesByOwnerV2(call);
     }
   );
@@ -210,9 +199,8 @@ export const makeZkClientLazy = (call: RpcCaller): ZkClientLazy => {
     obj,
     "getCompressionSignaturesForAccount",
     async () => {
-      const { makeGetCompressionSignaturesForAccount } = await import(
-        "./methods/getCompressionSignaturesForAccount"
-      );
+      const { makeGetCompressionSignaturesForAccount } =
+        await import("./methods/getCompressionSignaturesForAccount");
       return makeGetCompressionSignaturesForAccount(call);
     }
   );
@@ -221,9 +209,8 @@ export const makeZkClientLazy = (call: RpcCaller): ZkClientLazy => {
     obj,
     "getCompressionSignaturesForAddress",
     async () => {
-      const { makeGetCompressionSignaturesForAddress } = await import(
-        "./methods/getCompressionSignaturesForAddress"
-      );
+      const { makeGetCompressionSignaturesForAddress } =
+        await import("./methods/getCompressionSignaturesForAddress");
       return makeGetCompressionSignaturesForAddress(call);
     }
   );
@@ -232,9 +219,8 @@ export const makeZkClientLazy = (call: RpcCaller): ZkClientLazy => {
     obj,
     "getCompressionSignaturesForOwner",
     async () => {
-      const { makeGetCompressionSignaturesForOwner } = await import(
-        "./methods/getCompressionSignaturesForOwner"
-      );
+      const { makeGetCompressionSignaturesForOwner } =
+        await import("./methods/getCompressionSignaturesForOwner");
       return makeGetCompressionSignaturesForOwner(call);
     }
   );
@@ -243,9 +229,8 @@ export const makeZkClientLazy = (call: RpcCaller): ZkClientLazy => {
     obj,
     "getCompressionSignaturesForTokenOwner",
     async () => {
-      const { makeGetCompressionSignaturesForTokenOwner } = await import(
-        "./methods/getCompressionSignaturesForTokenOwner"
-      );
+      const { makeGetCompressionSignaturesForTokenOwner } =
+        await import("./methods/getCompressionSignaturesForTokenOwner");
       return makeGetCompressionSignaturesForTokenOwner(call);
     }
   );
@@ -254,9 +239,8 @@ export const makeZkClientLazy = (call: RpcCaller): ZkClientLazy => {
     obj,
     "getIndexerHealth",
     async () => {
-      const { makeGetIndexerHealth } = await import(
-        "./methods/getIndexerHealth"
-      );
+      const { makeGetIndexerHealth } =
+        await import("./methods/getIndexerHealth");
       return makeGetIndexerHealth(call);
     }
   );
@@ -274,9 +258,8 @@ export const makeZkClientLazy = (call: RpcCaller): ZkClientLazy => {
     obj,
     "getLatestCompressionSignatures",
     async () => {
-      const { makeGetLatestCompressionSignatures } = await import(
-        "./methods/getLatestCompressionSignatures"
-      );
+      const { makeGetLatestCompressionSignatures } =
+        await import("./methods/getLatestCompressionSignatures");
       return makeGetLatestCompressionSignatures(call);
     }
   );
@@ -285,9 +268,8 @@ export const makeZkClientLazy = (call: RpcCaller): ZkClientLazy => {
     obj,
     "getLatestNonVotingSignatures",
     async () => {
-      const { makeGetLatestNonVotingSignatures } = await import(
-        "./methods/getLatestNonVotingSignatures"
-      );
+      const { makeGetLatestNonVotingSignatures } =
+        await import("./methods/getLatestNonVotingSignatures");
       return makeGetLatestNonVotingSignatures(call);
     }
   );
@@ -296,9 +278,8 @@ export const makeZkClientLazy = (call: RpcCaller): ZkClientLazy => {
     obj,
     "getMultipleCompressedAccountProofs",
     async () => {
-      const { makeGetMultipleCompressedAccountProofs } = await import(
-        "./methods/getMultipleCompressedAccountProofs"
-      );
+      const { makeGetMultipleCompressedAccountProofs } =
+        await import("./methods/getMultipleCompressedAccountProofs");
       return makeGetMultipleCompressedAccountProofs(call);
     }
   );
@@ -307,9 +288,8 @@ export const makeZkClientLazy = (call: RpcCaller): ZkClientLazy => {
     obj,
     "getMultipleCompressedAccounts",
     async () => {
-      const { makeGetMultipleCompressedAccounts } = await import(
-        "./methods/getMultipleCompressedAccounts"
-      );
+      const { makeGetMultipleCompressedAccounts } =
+        await import("./methods/getMultipleCompressedAccounts");
       return makeGetMultipleCompressedAccounts(call);
     }
   );
@@ -318,9 +298,8 @@ export const makeZkClientLazy = (call: RpcCaller): ZkClientLazy => {
     obj,
     "getMultipleNewAddressProofs",
     async () => {
-      const { makeGetMultipleNewAddressProofs } = await import(
-        "./methods/getMultipleNewAddressProofs"
-      );
+      const { makeGetMultipleNewAddressProofs } =
+        await import("./methods/getMultipleNewAddressProofs");
       return makeGetMultipleNewAddressProofs(call);
     }
   );
@@ -329,9 +308,8 @@ export const makeZkClientLazy = (call: RpcCaller): ZkClientLazy => {
     obj,
     "getMultipleNewAddressProofsV2",
     async () => {
-      const { makeGetMultipleNewAddressProofsV2 } = await import(
-        "./methods/getMultipleNewAddressProofsV2"
-      );
+      const { makeGetMultipleNewAddressProofsV2 } =
+        await import("./methods/getMultipleNewAddressProofsV2");
       return makeGetMultipleNewAddressProofsV2(call);
     }
   );
@@ -340,9 +318,8 @@ export const makeZkClientLazy = (call: RpcCaller): ZkClientLazy => {
     obj,
     "getTransactionWithCompressionInfo",
     async () => {
-      const { makeGetTransactionWithCompressionInfo } = await import(
-        "./methods/getTransactionWithCompressionInfo"
-      );
+      const { makeGetTransactionWithCompressionInfo } =
+        await import("./methods/getTransactionWithCompressionInfo");
       return makeGetTransactionWithCompressionInfo(call);
     }
   );
@@ -351,9 +328,8 @@ export const makeZkClientLazy = (call: RpcCaller): ZkClientLazy => {
     obj,
     "getValidityProof",
     async () => {
-      const { makeGetValidityProof } = await import(
-        "./methods/getValidityProof"
-      );
+      const { makeGetValidityProof } =
+        await import("./methods/getValidityProof");
       return makeGetValidityProof(call);
     }
   );
@@ -362,9 +338,8 @@ export const makeZkClientLazy = (call: RpcCaller): ZkClientLazy => {
     obj,
     "getSignaturesForAsset",
     async () => {
-      const { makeGetSignaturesForAsset } = await import(
-        "./methods/getSignaturesForAsset"
-      );
+      const { makeGetSignaturesForAsset } =
+        await import("./methods/getSignaturesForAsset");
       return makeGetSignaturesForAsset(call);
     }
   );


### PR DESCRIPTION
This PR cleans up three pre-existing issues in `src/auth/` surfaced by `pnpm build` and `pnpm tsc --noEmit`:
- Circular dependency re `src/auth/checkout.ts` -> `src/auth/pollPayment.ts` -> `src/auth/checkout.ts`
- `Address` type issues in `buildTokenTransfer.test.ts`
- Spread arg type error in `checkBalances.test.ts`