### PR TITLE
chore(meta): Fill Out `package.json` and Restrict Published Files

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "zk-compression"
   ],
   "author": "Helius",
-  "license": "ISC",
+  "license": "MIT",
   "dependencies": {
     "bs58": "^6.0.0",
     "tslib": "^2.8.1"

--- a/package.json
+++ b/package.json
@@ -1,8 +1,26 @@
 {
   "name": "helius-sdk",
   "version": "2.2.2",
-  "description": "A Helius TypeScript SDK for building the future of Solana",
+  "description": "A Helius TypeScript SDK for building the future of Solana — DAS API, Sender, Webhooks, Laserstream, ZK Compression, and Solana RPC primitives. Built on @solana/kit.",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/helius-labs/helius-sdk.git"
+  },
+  "bugs": {
+    "url": "https://github.com/helius-labs/helius-sdk/issues"
+  },
+  "homepage": "https://github.com/helius-labs/helius-sdk#readme",
+  "engines": {
+    "node": ">=20"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "SECURITY.md",
+    "CHANGELOG.md"
+  ],
   "exports": {
     ".": {
       "types": "./dist/esm/rpc/index.d.ts",
@@ -103,9 +121,20 @@
     "helius",
     "solana",
     "web3",
-    "crypto",
-    "api",
-    "sdk"
+    "sdk",
+    "typescript",
+    "rpc",
+    "das",
+    "das-api",
+    "nft",
+    "compressed-nft",
+    "cnft",
+    "webhooks",
+    "laserstream",
+    "sender",
+    "priority-fees",
+    "smart-transactions",
+    "zk-compression"
   ],
   "author": "Helius",
   "license": "ISC",


### PR DESCRIPTION
This PR fills in the npm metadata fields the package was missing and adds a `files` allowlist so we ship only what consumers actually need. This does not result in any changes to runtime behavior; same functionality, a cleaner published shape, with an ~8% reduction in tarball size