### PR TITLE
chore(release): Bump to v2.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helius-sdk",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "description": "A Helius TypeScript SDK for building the future of Solana — DAS API, Sender, Webhooks, Laserstream, ZK Compression, and Solana RPC primitives. Built on @solana/kit.",
   "type": "module",
   "repository": {


### PR DESCRIPTION
This PR bumps `package.json` `version` from `2.2.2` to `2.3.0` ahead of the next npm publish. It's only a one-line diff because `src/version.ts` is regenerated by the build's `prebuild` script (i.e., it's gitignored), so this single field bump propagates correctly to the SDK's User-Agent header at build time