### PR TITLE
fix(rpc): Satisft Kit's Header Type at Transport Call Sites

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -1,9 +1,24 @@
+import type { createDefaultRpcTransport } from "@solana/kit";
 import { version } from "./version";
 
 const getEnvironment = (): "web" | "server" =>
   typeof window !== "undefined" ? "web" : "server";
 
 export const SDK_USER_AGENT = `helius-node-sdk/${version} (${getEnvironment()})`;
+
+/**
+ * Header shape accepted by `@solana/kit`'s `createDefaultRpcTransport` —
+ * a structural subset of `Record<string, string>` that forbids browser-
+ * reserved headers (Proxy-*, Sec-*, etc.). Derived from kit's exported
+ * function signature so we don't need a direct dep on
+ * `@solana/rpc-transport-http`. The `?: never` markers in kit's type
+ * don't survive object spread, so RPC transport call sites pass the
+ * result of `getSDKHeaders` cast to this type; `fetch()`-based call
+ * sites use the plain `Record<string, string>` return shape directly.
+ */
+export type AllowedRpcHeaders = NonNullable<
+  Parameters<typeof createDefaultRpcTransport>[0]["headers"]
+>;
 
 /**
  * Sanitize a client identifier string, stripping non-printable ASCII.

--- a/src/rpc/createHelius.eager.ts
+++ b/src/rpc/createHelius.eager.ts
@@ -8,7 +8,7 @@ import {
 } from "@solana/kit";
 import { wrapAutoSend } from "./wrapAutoSend";
 import { makeRpcCaller } from "./caller";
-import { getSDKHeaders } from "../http";
+import { getSDKHeaders, type AllowedRpcHeaders } from "../http";
 
 import { GetAssetFn, makeGetAsset } from "./methods/getAsset";
 import { GetAssetBatchFn, makeGetAssetBatch } from "./methods/getAssetBatch";
@@ -153,7 +153,7 @@ export const createHeliusEager = ({
   const solanaApi = createSolanaRpcApi(DEFAULT_RPC_CONFIG);
   const transport = createDefaultRpcTransport({
     url,
-    headers: getSDKHeaders(userAgent),
+    headers: getSDKHeaders(userAgent) as AllowedRpcHeaders,
   });
 
   let baseRpc = createRpc({ api: solanaApi, transport });

--- a/src/rpc/index.ts
+++ b/src/rpc/index.ts
@@ -5,7 +5,7 @@ import {
   DEFAULT_RPC_CONFIG,
 } from "@solana/kit";
 
-import { getSDKHeaders } from "../http";
+import { getSDKHeaders, type AllowedRpcHeaders } from "../http";
 
 import { wrapAutoSend } from "./wrapAutoSend";
 import type { WebhookClient } from "../webhooks/client";
@@ -199,7 +199,7 @@ export const createHelius = ({
   const solanaApi = createSolanaRpcApi(DEFAULT_RPC_CONFIG);
   const baseTransport = createDefaultRpcTransport({
     url,
-    headers: getSDKHeaders(userAgent),
+    headers: getSDKHeaders(userAgent) as AllowedRpcHeaders,
   });
   const transport = async <TResponse>(
     request: Parameters<typeof baseTransport>[0]


### PR DESCRIPTION
This PR resolves the two long-standing `tsc --noEmit` errors where each call site passes `getSDKHeaders(userAgent)` (typed `Record<string, string>`) into `createDefaultRpcTransport({ url, headers })`, which expects Kit's `AllowedHttpRequestHeaders` shape; a structurally stricter type that forbids `Proxy-*`, `Sec-*`, and several other browser-reserved header keys via `?: never` markers