### PR TITLE
docs(agents): Replace Removed `agenticSignup` Ref with `signupAndPay`

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -124,7 +124,6 @@ src/
     tests/
   auth/
     client.ts                     # makeAuthClient — standalone import only
-    agenticSignup.ts
     types.ts
     tests/
   types/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -433,9 +433,21 @@ const projects = await helius.auth.listProjects(token);                         
 const project = await helius.auth.createProject(token);                          // Create project (needs JWT)
 const apiKey = await helius.auth.createApiKey(token, project.id, address);       // Create API key (needs JWT)
 
-// Or use the all-in-one shortcut:
-const result = await helius.auth.agenticSignup({ secretKey: keypair.secretKey }); // Full automated flow
-// result: { jwt, walletAddress, projectId, apiKey, endpoints, credits }
+// Or use the all-in-one shortcut (signs the auth message, creates a hosted
+// checkout, auto-pays USDC + memo from the local keypair, polls activation):
+const result = await helius.auth.signupAndPay({
+  secretKey: keypair.secretKey,
+  plan: "agent",
+  email: "you@example.com",
+  firstName: "Jane",
+  lastName: "Doe",
+});
+// Discriminated by `result.kind`:
+//   "completed"          — { jwt, walletAddress, projectId, apiKey, endpoints, txSignature, paymentIntentId }
+//   "already_subscribed" — { jwt, walletAddress, projectId, apiKey, endpoints }
+//   "upgrade_required"   — { jwt, walletAddress, currentPlan, ... }
+//   "pending"            — poll timed out after payment; resume with the returned txSignature + paymentLink
+//   "expired" / "failed" — payment never completed; inspect `paymentIntentId` (and `reason` for failed)
 ```
 
 ## Documentation


### PR DESCRIPTION
This PR fixes the single remaining stale reference to the auth API removed in #314 in `AGENTS.md`. The file pointed AI agents (e.g., Claude, Cursor, Copilot) to `helius.auth.agenticSignup(...)`, but the recommended "all-in-one shortcut" no longer exists

This PR replaces it with `signupAndPay`, the direct successor that signs the auth message, creates a hosted checkout, auto-pays USDC + memo from the local keypair, and polls activation