### PR TITLE
docs(copilot): Refresh stale src/auth/ sketch

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -124,7 +124,11 @@ src/
     tests/
   auth/
     client.ts                     # makeAuthClient — standalone import only
-    agenticSignup.ts
+    signup.ts                     # JWT-based step-by-step signup
+    signupAndPay.ts               # All-in-one signup + USDC payment
+    checkout.ts                   # Hosted checkout flow
+    payUSDC.ts                    # USDC transfer with memo
+    pollPayment.ts                # Poll payment activation
     types.ts
     tests/
   types/


### PR DESCRIPTION
## Summary

- The `src/auth/` block in `.github/copilot-instructions.md` (Project Structure section) listed `agenticSignup.ts` — a file deleted in #314 — and only two source files at a time when the namespace has grown to ~33 files.
- Replace the entry with an illustrative ~8-file sketch covering the signup, hosted checkout, USDC payment, and activation-polling flows, matching the granularity used for sibling namespaces (`rpc/`, `transactions/`, `webhooks/`, etc.) in the same file.

## Context

`signupAndPay.ts` was introduced as the unified replacement in #312, and `agenticSignup.ts` was deleted shortly after in #314 — a replacement across two PRs, not a single-commit rename. The companion fix for the parallel `helius.auth.agenticSignup(...)` reference in `AGENTS.md` is on the [`docs/agents-md-stale-signup-ref`](https://github.com/helius-labs/helius-sdk/tree/docs/agents-md-stale-signup-ref) branch (commit 4c90bfe) and is being landed separately; the `copilot-instructions.md` sketch was explicitly out of scope there.

`CLAUDE.md` already uses a one-line summary for `auth/` (`auth/  # Agent authentication & signup`) and does not need to change. `README.md` already references the correct method names and example paths.

## Test plan

- [ ] `grep -n "agenticSignup" .github/copilot-instructions.md` returns no matches
- [ ] Every filename in the new sketch resolves (`client.ts`, `signup.ts`, `signupAndPay.ts`, `checkout.ts`, `payUSDC.ts`, `pollPayment.ts`, `types.ts`, `tests/`)
- [ ] Indentation and comment column match surrounding namespace blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)