### PR TITLE
feat(ci): Add Typecheck Gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Lint
         run: pnpm lint
 
+      - name: Type check
+        run: pnpm typecheck
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,9 +17,9 @@ pnpm run docs:build       # Generate TypeDoc API docs to docs/ (gitignored)
 pnpm run docs:open        # Generate docs and open in browser via local HTTP server
 ```
 
-Before submitting a PR, run: `pnpm format && pnpm lint && pnpm test && pnpm check-bundle`
+Before submitting a PR, run: `pnpm format && pnpm lint && pnpm typecheck && pnpm test && pnpm check-bundle`
 
-CI runs formatting, linting, tests, build, tree-shake checks, and bundle size checks on every push and PR to `main`.
+CI runs formatting, linting, type checking, tests, build, tree-shake checks, and bundle size checks on every push and PR to `main`.
 
 ## Project Structure
 

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "build": "rimraf dist && rollup -c",
     "prepare": "simple-git-hooks && pnpm run build",
     "lint": "eslint src",
+    "typecheck": "tsc --noEmit",
     "format": "prettier --write 'src/**/*.{js,ts,json,md}'",
     "format:check": "prettier --cache --check 'src/**/*.{js,ts,json,md}'",
     "bundle:size": "bundlemon",


### PR DESCRIPTION
This PR adds an explicit `tsc --noEmit` type-check step to CI, gated within the existing `lint` job. It locks in the clean type state achieved by PRs #319, #322, and #323, as type errors were only emitted as warnings and didn't fail the build