### PR TITLE
fix(api): Migrate v0 REST Endpoints to `api-mainnet.helius-rpc.com`

### DIFF
--- a/src/enhanced/client.eager.ts
+++ b/src/enhanced/client.eager.ts
@@ -51,7 +51,7 @@ export const makeEnhancedTxClientEager = (
   const base =
     network === "devnet"
       ? "https://api-devnet.helius.xyz/v0"
-      : "https://api.helius.xyz/v0";
+      : "https://api-mainnet.helius-rpc.com/v0";
 
   const getTransactions: EnhancedTxClient["getTransactions"] = async ({
     transactions,

--- a/src/webhooks/createWebhook.ts
+++ b/src/webhooks/createWebhook.ts
@@ -6,7 +6,7 @@ export const createWebhook = async (
   params: CreateWebhookRequest,
   userAgent?: string
 ): Promise<Webhook> => {
-  const url = `https://api.helius.xyz/v0/webhooks?api-key=${apiKey}`;
+  const url = `https://api-mainnet.helius-rpc.com/v0/webhooks?api-key=${apiKey}`;
 
   const response = await fetch(url, {
     method: "POST",

--- a/src/webhooks/deleteWebhook.ts
+++ b/src/webhooks/deleteWebhook.ts
@@ -5,7 +5,7 @@ export const deleteWebhook = async (
   webhookID: string,
   userAgent?: string
 ): Promise<boolean> => {
-  const url = `https://api.helius.xyz/v0/webhooks/${webhookID}?api-key=${apiKey}`;
+  const url = `https://api-mainnet.helius-rpc.com/v0/webhooks/${webhookID}?api-key=${apiKey}`;
 
   const response = await fetch(url, {
     method: "DELETE",

--- a/src/webhooks/getAllWebhooks.ts
+++ b/src/webhooks/getAllWebhooks.ts
@@ -5,7 +5,7 @@ export const getAllWebhooks = async (
   apiKey: string,
   userAgent?: string
 ): Promise<Webhook[]> => {
-  const url = `https://api.helius.xyz/v0/webhooks?api-key=${apiKey}`;
+  const url = `https://api-mainnet.helius-rpc.com/v0/webhooks?api-key=${apiKey}`;
 
   const response = await fetch(url, {
     method: "GET",

--- a/src/webhooks/getWebhook.ts
+++ b/src/webhooks/getWebhook.ts
@@ -6,7 +6,7 @@ export const getWebhook = async (
   webhookID: string,
   userAgent?: string
 ): Promise<Webhook> => {
-  const url = `https://api.helius.xyz/v0/webhooks/${webhookID}?api-key=${apiKey}`;
+  const url = `https://api-mainnet.helius-rpc.com/v0/webhooks/${webhookID}?api-key=${apiKey}`;
 
   const response = await fetch(url, {
     method: "GET",

--- a/src/webhooks/tests/createWebhook.test.ts
+++ b/src/webhooks/tests/createWebhook.test.ts
@@ -43,7 +43,7 @@ describe("createWebhook Tests", () => {
 
     expect(result).toEqual(mockResponse);
     expect(mockFetch).toHaveBeenCalledWith(
-      `https://api.helius.xyz/v0/webhooks?api-key=test-key`,
+      `https://api-mainnet.helius-rpc.com/v0/webhooks?api-key=test-key`,
       expect.objectContaining({
         method: "POST",
         headers: expect.objectContaining({

--- a/src/webhooks/tests/deleteWebhook.test.ts
+++ b/src/webhooks/tests/deleteWebhook.test.ts
@@ -22,7 +22,7 @@ describe("deleteWebhook Tests", () => {
     const result = await rpc.webhooks.delete("yavin-base-1138");
     expect(result).toBe(true); // Updated to expect true
     expect(mockFetch).toHaveBeenCalledWith(
-      `https://api.helius.xyz/v0/webhooks/yavin-base-1138?api-key=test-key`,
+      `https://api-mainnet.helius-rpc.com/v0/webhooks/yavin-base-1138?api-key=test-key`,
       expect.objectContaining({
         method: "DELETE",
       })

--- a/src/webhooks/tests/getAllWebhooks.test.ts
+++ b/src/webhooks/tests/getAllWebhooks.test.ts
@@ -44,7 +44,7 @@ describe("getAllWebhooks Tests", () => {
 
     expect(result).toEqual(mockWebhooks);
     expect(mockFetch).toHaveBeenCalledWith(
-      `https://api.helius.xyz/v0/webhooks?api-key=test-key`,
+      `https://api-mainnet.helius-rpc.com/v0/webhooks?api-key=test-key`,
       expect.objectContaining({
         method: "GET",
         headers: expect.objectContaining({
@@ -64,7 +64,7 @@ describe("getAllWebhooks Tests", () => {
 
     expect(result).toEqual([]);
     expect(mockFetch).toHaveBeenCalledWith(
-      `https://api.helius.xyz/v0/webhooks?api-key=test-key`,
+      `https://api-mainnet.helius-rpc.com/v0/webhooks?api-key=test-key`,
       expect.objectContaining({
         method: "GET",
       })

--- a/src/webhooks/tests/getWebhook.test.ts
+++ b/src/webhooks/tests/getWebhook.test.ts
@@ -33,7 +33,7 @@ describe("getWebhook Tests", () => {
 
     expect(result).toEqual(mockWebhook);
     expect(mockFetch).toHaveBeenCalledWith(
-      `https://api.helius.xyz/v0/webhooks/yavin-base-1138?api-key=test-key`,
+      `https://api-mainnet.helius-rpc.com/v0/webhooks/yavin-base-1138?api-key=test-key`,
       expect.objectContaining({
         method: "GET",
         headers: expect.objectContaining({

--- a/src/webhooks/tests/toggleWebhook.test.ts
+++ b/src/webhooks/tests/toggleWebhook.test.ts
@@ -35,7 +35,7 @@ describe("toggleWebhook Tests", () => {
     expect(result).toEqual(mockResponse);
     expect(result.active).toBe(true);
     expect(mockFetch).toHaveBeenCalledWith(
-      `https://api.helius.xyz/v0/webhooks/yavin-base-1138?api-key=test-key`,
+      `https://api-mainnet.helius-rpc.com/v0/webhooks/yavin-base-1138?api-key=test-key`,
       expect.objectContaining({
         method: "PATCH",
         headers: expect.objectContaining({
@@ -68,7 +68,7 @@ describe("toggleWebhook Tests", () => {
     expect(result).toEqual(mockResponse);
     expect(result.active).toBe(false);
     expect(mockFetch).toHaveBeenCalledWith(
-      `https://api.helius.xyz/v0/webhooks/death-star-plans-66?api-key=test-key`,
+      `https://api-mainnet.helius-rpc.com/v0/webhooks/death-star-plans-66?api-key=test-key`,
       expect.objectContaining({
         method: "PATCH",
         body: JSON.stringify({ active: false }),

--- a/src/webhooks/tests/updateWebhook.test.ts
+++ b/src/webhooks/tests/updateWebhook.test.ts
@@ -39,7 +39,7 @@ describe("updateWebhook Tests", () => {
 
     expect(result).toEqual(mockResponse);
     expect(mockFetch).toHaveBeenCalledWith(
-      `https://api.helius.xyz/v0/webhooks/yavin-base-1138?api-key=test-key`,
+      `https://api-mainnet.helius-rpc.com/v0/webhooks/yavin-base-1138?api-key=test-key`,
       expect.objectContaining({
         method: "PUT",
         headers: expect.objectContaining({
@@ -74,7 +74,7 @@ describe("updateWebhook Tests", () => {
 
     expect(result).toEqual(mockResponse);
     expect(mockFetch).toHaveBeenCalledWith(
-      `https://api.helius.xyz/v0/webhooks/death-star-plans-66?api-key=test-key`,
+      `https://api-mainnet.helius-rpc.com/v0/webhooks/death-star-plans-66?api-key=test-key`,
       expect.objectContaining({
         method: "PUT",
         body: JSON.stringify(mockParams),

--- a/src/webhooks/toggleWebhook.ts
+++ b/src/webhooks/toggleWebhook.ts
@@ -7,7 +7,7 @@ export const toggleWebhook = async (
   active: boolean,
   userAgent?: string
 ): Promise<Webhook> => {
-  const url = `https://api.helius.xyz/v0/webhooks/${webhookID}?api-key=${apiKey}`;
+  const url = `https://api-mainnet.helius-rpc.com/v0/webhooks/${webhookID}?api-key=${apiKey}`;
 
   const response = await fetch(url, {
     method: "PATCH",

--- a/src/webhooks/updateWebhook.ts
+++ b/src/webhooks/updateWebhook.ts
@@ -7,7 +7,7 @@ export const updateWebhook = async (
   params: UpdateWebhookRequest,
   userAgent?: string
 ): Promise<Webhook> => {
-  const url = `https://api.helius.xyz/v0/webhooks/${webhookID}?api-key=${apiKey}`;
+  const url = `https://api-mainnet.helius-rpc.com/v0/webhooks/${webhookID}?api-key=${apiKey}`;
 
   const response = await fetch(url, {
     method: "PUT",


### PR DESCRIPTION
This PR aligns the SDK with the canonical hostname documented in the official Helius docs for the v0 REST surfaces. The current `api.helius.xyz` hostname still resolves today (otherwise existing consumers would be broken), but the docs now point at `api-mainnet.helius-rpc.com` as the official endpoint for these APIs, and the SDK should match the docs out of the box