### PR TITLE
feat(wallet): Add `getBalanceAt` For Historical Token Balances

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -401,6 +401,7 @@ helius.stake.getHeliusStakeAccounts(wallet)                  // List stake accou
 
 ```typescript
 helius.wallet.getBalances({ wallet })                       // Token balances
+helius.wallet.getBalanceAt({ wallet, mint, slot })          // Historical balance (time/datetime/slot)
 helius.wallet.getHistory({ wallet })                        // Transaction history
 helius.wallet.getTransfers({ wallet })                      // Transfer history
 helius.wallet.getIdentity({ wallet })                       // Known identity lookup

--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ Query wallet data including identity, balances, history, and transfers. Availabl
 - [`getIdentity()`](https://www.helius.dev/docs/api-reference/wallet-api/identity): Get wallet identity for known addresses (e.g., exchanges, protocols)
 - [`getBatchIdentity()`](https://www.helius.dev/docs/api-reference/wallet-api/identity): Batch identity lookup for up to 100 addresses
 - [`getBalances()`](https://www.helius.dev/docs/api-reference/wallet-api/balances): Get all token and NFT balances with USD values and pagination
+- [`getBalanceAt()`](https://www.helius.dev/docs/api-reference/wallet-api/balance-at): Get a wallet's balance of a specific token or native SOL at a past timestamp, datetime, or slot
 - [`getHistory()`](https://www.helius.dev/docs/api-reference/wallet-api/history): Fetch transaction history with balance changes and pagination
 - [`getTransfers()`](https://www.helius.dev/docs/api-reference/wallet-api/transfers): Get all token transfer activity with sender/recipient information
 - [`getFundedBy()`](https://www.helius.dev/docs/api-reference/wallet-api/funded-by): Discover the original funding source for a wallet

--- a/examples/wallet/getBalanceAt.ts
+++ b/examples/wallet/getBalanceAt.ts
@@ -1,0 +1,58 @@
+import { createHelius } from "helius-sdk";
+
+(async () => {
+  const apiKey = ""; // From Helius dashboard
+  const helius = createHelius({ apiKey });
+
+  // Replace with the wallet address you want to check
+  const walletAddress = "5tzFkiKscXHK5ZXCGbXZxdw7gTjjD1mBwuoFbhUvuAi9";
+
+  // USDC mint. For native SOL, use So11111111111111111111111111111111111111111
+  const mint = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+
+  try {
+    console.log(`\nHistorical balance for: ${walletAddress}`);
+    console.log("=".repeat(80));
+
+    // Provide exactly one of slot, time, or datetime.
+    // Prefer `slot` for exact, deterministic results — block times can drift.
+    const atSlot = await helius.wallet.getBalanceAt({
+      wallet: walletAddress,
+      mint,
+      slot: 313000000,
+    });
+
+    console.log(`\nBy slot (${atSlot.requested.slot}):`);
+    console.log(`  Balance: ${atSlot.balance} (raw: ${atSlot.balanceRaw})`);
+    console.log(`  Decimals: ${atSlot.decimals}, isNative: ${atSlot.isNative}`);
+
+    // `asOf` is the transaction the balance was read from.
+    // It is null when the wallet held none of the token by that point.
+    if (atSlot.asOf) {
+      console.log(`  As of tx: ${atSlot.asOf.signature} (slot ${atSlot.asOf.slot})`);
+    } else {
+      console.log("  No matching activity at or before this point — balance is 0");
+    }
+
+    // Query by Unix timestamp (seconds) instead of slot
+    const atTime = await helius.wallet.getBalanceAt({
+      wallet: walletAddress,
+      mint,
+      time: 1736536800,
+    });
+    console.log(`\nBy time (${atTime.requested.time}): ${atTime.balance}`);
+
+    // Query by datetime string (interpreted as UTC unless a timezone is given).
+    // `requested.time` echoes the resolved epoch seconds.
+    const atDatetime = await helius.wallet.getBalanceAt({
+      wallet: walletAddress,
+      mint,
+      datetime: "2025-01-10 19:20:00",
+    });
+    console.log(
+      `\nBy datetime (${atDatetime.requested.datetime} -> ${atDatetime.requested.time}): ${atDatetime.balance}`
+    );
+  } catch (error: any) {
+    console.error("\nError fetching historical balance:", error.message);
+  }
+})();

--- a/examples/wallet/getBalanceAt.ts
+++ b/examples/wallet/getBalanceAt.ts
@@ -29,9 +29,13 @@ import { createHelius } from "helius-sdk";
     // `asOf` is the transaction the balance was read from.
     // It is null when the wallet held none of the token by that point.
     if (atSlot.asOf) {
-      console.log(`  As of tx: ${atSlot.asOf.signature} (slot ${atSlot.asOf.slot})`);
+      console.log(
+        `  As of tx: ${atSlot.asOf.signature} (slot ${atSlot.asOf.slot})`
+      );
     } else {
-      console.log("  No matching activity at or before this point — balance is 0");
+      console.log(
+        "  No matching activity at or before this point — balance is 0"
+      );
     }
 
     // Query by Unix timestamp (seconds) instead of slot
@@ -49,8 +53,9 @@ import { createHelius } from "helius-sdk";
       mint,
       datetime: "2025-01-10 19:20:00",
     });
+    const { datetime, time } = atDatetime.requested;
     console.log(
-      `\nBy datetime (${atDatetime.requested.datetime} -> ${atDatetime.requested.time}): ${atDatetime.balance}`
+      `\nBy datetime (${datetime} -> ${time}): ${atDatetime.balance}`
     );
   } catch (error: any) {
     console.error("\nError fetching historical balance:", error.message);

--- a/src/wallet/client.eager.ts
+++ b/src/wallet/client.eager.ts
@@ -6,6 +6,8 @@ import type {
   GetBatchIdentityResponse,
   GetBalancesRequest,
   GetBalancesResponse,
+  GetBalanceAtRequest,
+  GetBalanceAtResponse,
   GetHistoryRequest,
   GetHistoryResponse,
   GetTransfersRequest,
@@ -16,6 +18,7 @@ import type {
 import { getIdentity } from "./getIdentity";
 import { getBatchIdentity } from "./getBatchIdentity";
 import { getBalances } from "./getBalances";
+import { getBalanceAt } from "./getBalanceAt";
 import { getHistory } from "./getHistory";
 import { getTransfers } from "./getTransfers";
 import { getFundedBy } from "./getFundedBy";
@@ -52,6 +55,8 @@ export const makeWalletClientEager = (
     getBatchIdentity(apiKey, p, userAgent),
   getBalances: (p: GetBalancesRequest): Promise<GetBalancesResponse> =>
     getBalances(apiKey, p, userAgent),
+  getBalanceAt: (p: GetBalanceAtRequest): Promise<GetBalanceAtResponse> =>
+    getBalanceAt(apiKey, p, userAgent),
   getHistory: (p: GetHistoryRequest): Promise<GetHistoryResponse> =>
     getHistory(apiKey, p, userAgent),
   getTransfers: (p: GetTransfersRequest): Promise<GetTransfersResponse> =>

--- a/src/wallet/client.ts
+++ b/src/wallet/client.ts
@@ -5,6 +5,8 @@ import type {
   GetBatchIdentityResponse,
   GetBalancesRequest,
   GetBalancesResponse,
+  GetBalanceAtRequest,
+  GetBalanceAtResponse,
   GetHistoryRequest,
   GetHistoryResponse,
   GetTransfersRequest,
@@ -68,6 +70,16 @@ export interface WalletClient {
   getBalances(params: GetBalancesRequest): Promise<GetBalancesResponse>;
 
   /**
+   * Get a wallet's balance of a specific token or native SOL at a past
+   * timestamp, datetime, or slot
+   *
+   * @param params - Request parameters including wallet, mint, and exactly one of time/datetime/slot
+   * @returns Historical balance, with amounts returned as strings to avoid precision loss
+   * @throws Error if HTTP error or invalid request
+   */
+  getBalanceAt(params: GetBalanceAtRequest): Promise<GetBalanceAtResponse>;
+
+  /**
    * Get transaction history with balance changes
    *
    * @param params - Request parameters including wallet address and pagination options
@@ -126,6 +138,8 @@ export const makeWalletClient = (
     ),
   getBalances: async (p) =>
     (await import("./getBalances.js")).getBalances(apiKey, p, userAgent),
+  getBalanceAt: async (p) =>
+    (await import("./getBalanceAt.js")).getBalanceAt(apiKey, p, userAgent),
   getHistory: async (p) =>
     (await import("./getHistory.js")).getHistory(apiKey, p, userAgent),
   getTransfers: async (p) =>

--- a/src/wallet/getBalanceAt.ts
+++ b/src/wallet/getBalanceAt.ts
@@ -1,0 +1,79 @@
+import {
+  BASE_URL,
+  buildQueryString,
+  handleResponse,
+  getHeaders,
+} from "./utils";
+import type { GetBalanceAtRequest, GetBalanceAtResponse } from "./types";
+
+/**
+ * Get a wallet's balance of a specific token (or native SOL) at a point in the past
+ *
+ * The balance is read from the wallet's most recent transaction involving the
+ * token **at or before** the requested point in time — its post-transaction
+ * balance, which by definition held until the wallet's next transaction. This
+ * is an exact value, not an estimate.
+ *
+ * The point in the past is specified as **exactly one** of `time` (Unix seconds),
+ * `datetime` (string, interpreted as UTC unless an explicit timezone is given),
+ * or `slot`. For exact, deterministic results prefer `slot`, since block times
+ * reported by validators can drift by a few seconds.
+ *
+ * For native SOL, pass the pseudo-mint `So11111111111111111111111111111111111111111`
+ * as `mint`.
+ *
+ * A wallet with no matching activity at or before the requested point is **not**
+ * an error — the response has `balance: "0"` and `asOf: null`.
+ *
+ * Each request costs 100 credits.
+ *
+ * @beta The Wallet API is currently in beta. APIs and response formats may change.
+ *
+ * @param apiKey - Helius API key
+ * @param params - Request parameters including wallet, mint, and one of time/datetime/slot
+ * @returns Historical balance, returned as strings to avoid precision loss
+ * @throws Error if HTTP error or invalid request
+ *
+ * @example
+ * ```ts
+ * // Balance of USDC at a specific slot (exact and deterministic)
+ * const atSlot = await helius.wallet.getBalanceAt({
+ *   wallet: "5tzFkiKscXHK5ZXCGbXZxdw7gTjjD1mBwuoFbhUvuAi9",
+ *   mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+ *   slot: 313000000,
+ * });
+ *
+ * console.log(`${atSlot.balance} (raw: ${atSlot.balanceRaw})`);
+ *
+ * // Native SOL balance at a Unix timestamp
+ * const solAt = await helius.wallet.getBalanceAt({
+ *   wallet: "5tzFkiKscXHK5ZXCGbXZxdw7gTjjD1mBwuoFbhUvuAi9",
+ *   mint: "So11111111111111111111111111111111111111111",
+ *   time: 1736536800,
+ * });
+ * ```
+ */
+export const getBalanceAt = async (
+  apiKey: string,
+  params: GetBalanceAtRequest,
+  userAgent?: string
+): Promise<GetBalanceAtResponse> => {
+  const { wallet, mint, time, datetime, slot } = params;
+
+  const queryParams = {
+    "api-key": apiKey,
+    mint,
+    time,
+    datetime,
+    slot,
+  };
+
+  const url = `${BASE_URL}/${wallet}/balance-at${buildQueryString(queryParams)}`;
+
+  const response = await fetch(url, {
+    method: "GET",
+    headers: getHeaders(false, userAgent),
+  });
+
+  return handleResponse<GetBalanceAtResponse>(response);
+};

--- a/src/wallet/tests/getBalanceAt.test.ts
+++ b/src/wallet/tests/getBalanceAt.test.ts
@@ -119,7 +119,8 @@ describe("getBalanceAt Tests", () => {
     mockFetch.mockResolvedValue({
       ok: true,
       json: async () => ({
-        error: { code: 400, message: "Invalid mint" },
+        error: "Invalid mint",
+        code: 400,
       }),
     });
 

--- a/src/wallet/tests/getBalanceAt.test.ts
+++ b/src/wallet/tests/getBalanceAt.test.ts
@@ -1,0 +1,134 @@
+import { createHeliusEager as createHelius } from "../../rpc/createHelius.eager";
+import type { GetBalanceAtResponse } from "../types";
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch as jest.Mock;
+
+describe("getBalanceAt Tests", () => {
+  let rpc: ReturnType<typeof createHelius>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    rpc = createHelius({ apiKey: "test-key" });
+  });
+
+  it("Successfully retrieves a historical balance by slot", async () => {
+    const mockResponse: GetBalanceAtResponse = {
+      wallet: "5tzFkiKscXHK5ZXCGbXZxdw7gTjjD1mBwuoFbhUvuAi9",
+      mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+      isNative: false,
+      balance: "284961463.392936",
+      balanceRaw: "284961463392936",
+      decimals: 6,
+      requested: {
+        time: null,
+        slot: 313000000,
+        datetime: null,
+      },
+      asOf: {
+        slot: 313000000,
+        blockTime: 1736536794,
+        signature: "5Cyy7Mh9nVgFq3T8wJp2sKxR4dE6bA1uZoNcLrXmYqUpon",
+      },
+    };
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => mockResponse,
+    });
+
+    const result = await rpc.wallet.getBalanceAt({
+      wallet: "5tzFkiKscXHK5ZXCGbXZxdw7gTjjD1mBwuoFbhUvuAi9",
+      mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+      slot: 313000000,
+    });
+
+    expect(result).toEqual(mockResponse);
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "/v1/wallet/5tzFkiKscXHK5ZXCGbXZxdw7gTjjD1mBwuoFbhUvuAi9/balance-at"
+      ),
+      expect.objectContaining({
+        method: "GET",
+      })
+    );
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("slot=313000000"),
+      expect.anything()
+    );
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "mint=EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+      ),
+      expect.anything()
+    );
+  });
+
+  it("Passes a datetime query parameter (URL-encoded)", async () => {
+    const mockResponse: GetBalanceAtResponse = {
+      wallet: "5tzFkiKscXHK5ZXCGbXZxdw7gTjjD1mBwuoFbhUvuAi9",
+      mint: "So11111111111111111111111111111111111111111",
+      isNative: true,
+      balance: "12.5",
+      balanceRaw: "12500000000",
+      decimals: 9,
+      requested: {
+        time: 1736536800,
+        slot: null,
+        datetime: "2025-01-10 19:20:00",
+      },
+      asOf: null,
+    };
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => mockResponse,
+    });
+
+    const result = await rpc.wallet.getBalanceAt({
+      wallet: "5tzFkiKscXHK5ZXCGbXZxdw7gTjjD1mBwuoFbhUvuAi9",
+      mint: "So11111111111111111111111111111111111111111",
+      datetime: "2025-01-10 19:20:00",
+    });
+
+    expect(result.asOf).toBeNull();
+    expect(result.isNative).toBe(true);
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("datetime=2025-01-10%2019%3A20%3A00"),
+      expect.anything()
+    );
+  });
+
+  it("Handles HTTP errors", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 400,
+      text: async () =>
+        "Exactly one of time, datetime, or slot must be provided",
+    });
+
+    await expect(
+      rpc.wallet.getBalanceAt({
+        wallet: "5tzFkiKscXHK5ZXCGbXZxdw7gTjjD1mBwuoFbhUvuAi9",
+        mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+      })
+    ).rejects.toThrow("HTTP error! status: 400");
+  });
+
+  it("Handles API errors", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        error: { code: 400, message: "Invalid mint" },
+      }),
+    });
+
+    await expect(
+      rpc.wallet.getBalanceAt({
+        wallet: "5tzFkiKscXHK5ZXCGbXZxdw7gTjjD1mBwuoFbhUvuAi9",
+        mint: "not-a-mint",
+        slot: 313000000,
+      })
+    ).rejects.toThrow("Helius error:");
+  });
+});

--- a/src/wallet/types.ts
+++ b/src/wallet/types.ts
@@ -293,6 +293,95 @@ export interface GetTransfersResponse {
 }
 
 /**
+ * Request parameters for getting a wallet's historical token balance.
+ *
+ * Provide **exactly one** of `time`, `datetime`, or `slot` to specify the
+ * point in the past. For exact, deterministic results prefer `slot`, since
+ * block times reported by validators can drift by a few seconds.
+ */
+export interface GetBalanceAtRequest {
+  /** Solana wallet address (base58 encoded) */
+  wallet: string;
+  /**
+   * Token mint address. For native SOL, use the pseudo-mint
+   * `So11111111111111111111111111111111111111111`.
+   */
+  mint: string;
+  /**
+   * Unix timestamp in **seconds**. Returns the balance as of this time.
+   * Provide exactly one of `time`, `datetime`, or `slot`.
+   */
+  time?: number;
+  /**
+   * Datetime string. Accepted formats: `2025-01-10` (UTC midnight),
+   * `2025-01-10 19:20:00`, `2025-01-10T19:20:00` (seconds optional), or with an
+   * explicit timezone (`2025-01-10T19:20:00Z`, `...+02:00`). Interpreted as UTC
+   * unless an explicit timezone is included.
+   * Provide exactly one of `time`, `datetime`, or `slot`.
+   */
+  datetime?: string;
+  /**
+   * Slot number. Returns the balance as of this slot. Exact and deterministic.
+   * Provide exactly one of `time`, `datetime`, or `slot`.
+   */
+  slot?: number;
+}
+
+/**
+ * The transaction a historical balance was read from.
+ */
+export interface BalanceAtSource {
+  /** Slot of the transaction */
+  slot: number;
+  /** Block time of the transaction in Unix seconds (may be null) */
+  blockTime?: number | null;
+  /** Transaction signature */
+  signature: string;
+}
+
+/**
+ * Response from getBalanceAt endpoint.
+ *
+ * `balance` and `balanceRaw` are returned as **strings** to avoid precision
+ * loss on large values.
+ */
+export interface GetBalanceAtResponse {
+  /** Echo of the queried wallet address */
+  wallet: string;
+  /** Echo of the queried mint (the SOL pseudo-mint when native) */
+  mint: string;
+  /** Whether the result is native SOL */
+  isNative: boolean;
+  /**
+   * Human-readable amount as a decimal string (not a number, so large balances
+   * don't lose precision). Trailing zeros are trimmed.
+   */
+  balance: string;
+  /** Exact amount in the smallest unit (lamports for SOL), as a string */
+  balanceRaw: string;
+  /** Token decimals (9 for SOL) */
+  decimals: number;
+  /**
+   * Echo of the query. When `datetime` is used, `time` is also populated with
+   * the resolved epoch seconds so the UTC interpretation is visible.
+   */
+  requested: {
+    /** Requested time as epoch seconds (also set when `datetime` was used) */
+    time: number | null;
+    /** Requested slot, when `slot` was used */
+    slot: number | null;
+    /** The original datetime string, when `datetime` was used */
+    datetime: string | null;
+  };
+  /**
+   * The transaction the balance was read from. `null` when the wallet had no
+   * matching transaction at or before the requested point — meaning the balance
+   * is genuinely `0` (the wallet had not held the token by then), not an error.
+   */
+  asOf: BalanceAtSource | null;
+}
+
+/**
  * Wallet funding source information
  */
 export interface FundingSource {


### PR DESCRIPTION
This PR adds `helius.wallet.getBalanceAt()`, which wraps the new Wallet API endpoint `GET /v1/wallet/{wallet}/balance-at`. It returns a wallet's balance of a specific token (or native SOL) at a past point in time, specified as a Unix timestamp, a datetime string, or a slot

The balance is the wallet's post-transaction balance from its most recent transaction involving the token that occurred at or before the requested point, and is an exact value, not an estimate. A wallet with no matching activity returns `balance: "0"` with `asOf: null` rather than an error