### PR TITLE
fix(staking): fix epoch boundary in getWithdrawableAmount

### DIFF
--- a/src/staking/getWithdrawableAmount.ts
+++ b/src/staking/getWithdrawableAmount.ts
@@ -36,14 +36,19 @@ export const makeGetWithdrawableAmount = ({
     }
 
     // An initialized (undelegated) account has no delegation and is never
-    // active, so treat it as already cooled down.
-    const deactivationStr = info.stake?.delegation?.deactivationEpoch ?? "0";
+    // active, so it's always treated as already cooled down.
+    if (info.stake) {
+      const deactivationEpoch = BigInt(info.stake.delegation.deactivationEpoch);
+      const currentEpoch = BigInt((await rpc.getEpochInfo().send()).epoch);
 
-    const deactivationEpoch = BigInt(deactivationStr);
-    const currentEpoch = BigInt((await rpc.getEpochInfo().send()).epoch);
+      // Per the stake program's own state machine
+      // (Delegation::stake_activating_and_deactivating), the delegation is
+      // still "deactivating" (non-zero effective stake) through the epoch
+      // equal to deactivationEpoch — only fully inactive once currentEpoch
+      // strictly exceeds it.
+      if (deactivationEpoch >= currentEpoch) return 0;
+    }
 
-    // If still active (not yet cooled down), return 0
-    if (deactivationEpoch > currentEpoch) return 0;
     if (includeRentExempt) return Number(lamports);
 
     const rentExempt = await rpc

--- a/src/staking/tests/getWithdrawableAmount.test.ts
+++ b/src/staking/tests/getWithdrawableAmount.test.ts
@@ -112,4 +112,29 @@ describe("getWithdrawableAmount Tests", () => {
 
     expect(amt).toBe(Number(5_000_000n - rentExemptLamports));
   });
+
+  it("Returns 0 when deactivationEpoch equals currentEpoch (still deactivating)", async () => {
+    const rpc = mockRpcBase();
+    rpc.getAccountInfo.mockReturnValue({
+      send: () => ({ value: makeAccInfo(5_000_000n, 100n) }), // deactivationEpoch === currentEpoch (100)
+    });
+
+    const fn = makeGetWithdrawableAmount({ rpc });
+    const amt = await fn(stakeAccount);
+
+    expect(amt).toBe(0);
+    expect(rpc.getMinimumBalanceForRentExemption).not.toHaveBeenCalled();
+  });
+
+  it("Returns lamports minus rent once currentEpoch exceeds deactivationEpoch by one", async () => {
+    const rpc = mockRpcBase();
+    rpc.getAccountInfo.mockReturnValue({
+      send: () => ({ value: makeAccInfo(5_000_000n, 99n) }), // deactivationEpoch 99 < currentEpoch 100
+    });
+
+    const fn = makeGetWithdrawableAmount({ rpc });
+    const amt = await fn(stakeAccount);
+
+    expect(amt).toBe(Number(5_000_000n - rentExemptLamports));
+  });
 });


### PR DESCRIPTION
## Summary

`helius.stake.getWithdrawableAmount()` reported a delegated stake account as fully withdrawable one epoch before it actually was, because the deactivation-epoch check used `>` instead of `>=`.

Fixes #337

## Problem

At [`src/staking/getWithdrawableAmount.ts:46`](https://github.com/helius-labs/helius-sdk/blob/main/src/staking/getWithdrawableAmount.ts#L46):

```ts
if (deactivationEpoch > currentEpoch) return 0;
```

This only guards the strictly-greater case. Reproduction (mocking `deactivationEpoch: "100"`, `currentEpoch: 100n`):

```
Actual:   3000000
Expected: 0
```

## Root cause

Per the stake program's own state machine (`Delegation::stake_activating_and_deactivating`, see [`solana-program/stake`](https://github.com/solana-program/stake/blob/main/interface/src/state.rs)), a delegation is still in the **deactivating** state — with non-zero effective stake — through the epoch equal to `deactivationEpoch`. It only becomes fully inactive once the current epoch strictly *exceeds* `deactivationEpoch`. The SDK's `>` comparison instead treated `deactivationEpoch === currentEpoch` as already cooled down, one epoch early. A caller building a `createWithdrawTransaction` off that result during the equal-epoch window would have it rejected on-chain.

This line predates #336 (confirmed via `git blame` — original code from commit `123e82b`, Sept 2025) — a separate, pre-existing bug in the same function that #336 didn't touch.

## Fix

Scoped the epoch comparison to only run for delegated accounts (`info.stake` present), and changed `>` to `>=` for that case:

```ts
if (info.stake) {
  const deactivationEpoch = BigInt(info.stake.delegation.deactivationEpoch);
  const currentEpoch = BigInt((await rpc.getEpochInfo().send()).epoch);
  if (deactivationEpoch >= currentEpoch) return 0;
}
```

Considered a blind `>=` swap on the old single-expression form instead, but rejected it: the "initialized" (undelegated) branch added in #336 defaults `deactivationEpoch` to `"0"`, so a blind `>=` would make an initialized account register as "not yet withdrawable" whenever `currentEpoch` is `0` — an accidental coupling between two unrelated cases in one boolean expression. Scoping the check to the delegated branch keeps #336's undelegated-account handling completely untouched, and also skips an unnecessary `getEpochInfo()` call for that case.

## Tests

- `getWithdrawableAmount.test.ts`: "Returns 0 when deactivationEpoch equals currentEpoch (still deactivating)" — fails on `main` (`3000000` instead of `0`), passes here.
- `getWithdrawableAmount.test.ts`: "Returns lamports minus rent once currentEpoch exceeds deactivationEpoch by one" — confirms the fix doesn't overshoot the boundary.
- All 4 existing tests in this file still pass unchanged, including #336's "Treats an initialized (undelegated) account as fully withdrawable" test.
- Full suite: `pnpm test` → 117 suites / 446 tests passed.

## Compatibility / risk

Internal logic-only change to a public method's return value in one edge case (`deactivationEpoch === currentEpoch`). No signature change. Risk is limited to callers who were relying on the incorrect early-withdrawable signal — unlikely, since acting on it would already fail on-chain.

## Out of scope

Nothing else in `src/staking/` depends on or duplicates this comparison (checked `createWithdrawTransaction.ts`, `getStakeInstructions.ts`, `getHeliusStakeAccounts.ts`).
