### PR TITLE
feat(rpc): Expose Transport Augmentation Hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,35 @@ import { createHelius } from "helius-sdk";
 })();
 ```
 
+### Custom RPC transport (retries, failover)
+
+`createHelius` accepts a `transport` hook that lets you augment or replace the default RPC transport, following [`@solana/kit`'s transport-augmentation pattern](https://github.com/anza-xyz/kit#augmenting-transports). The hook receives the SDK's fully configured transport (Helius URL with your API key, SDK headers, and request-id stamping) and returns the transport the client will use for **all** JSON-RPC calls — standard Solana RPC and DAS/Helius methods alike.
+
+```ts
+import { createHelius, type RpcTransport } from "helius-sdk";
+
+const helius = createHelius({
+  apiKey,
+  transport: (defaultTransport): RpcTransport => async (request) => {
+    // Retry up to 3 times with exponential backoff
+    let lastError: unknown;
+    for (let attempt = 0; attempt < 3; attempt++) {
+      try {
+        return await defaultTransport(request);
+      } catch (error) {
+        lastError = error;
+        await new Promise((r) => setTimeout(r, 2 ** attempt * 100));
+      }
+    }
+    throw lastError;
+  },
+});
+```
+
+To replace the transport entirely (e.g., failover to a non-Helius endpoint), ignore the provided default: `transport: () => myCustomTransport`. See [`examples/helius/customTransport.ts`](examples/helius/customTransport.ts) for a full example.
+
+> **Note:** The hook covers JSON-RPC traffic only. WebSocket subscriptions (`helius.ws`) and the REST sub-clients (`webhooks`, `enhanced`, `wallet`, `admin`, `auth`) do not go through this transport.
+
 ### Larger transactions with version 1
 
 Agave 4.2 raises the maximum transaction size from 1,232 to 4,096 bytes ([SIMD-0296](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0296-larger-transactions.md)). That size is only available in the version 1 transaction format ([SIMD-0385](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0385-transaction-v1.md)). Legacy and v0 transactions are unaffected and remain the default.

--- a/README.md
+++ b/README.md
@@ -95,14 +95,14 @@ import { createHelius } from "helius-sdk";
 
 ### Custom RPC transport (retries, failover)
 
-`createHelius` accepts a `transport` hook that lets you augment or replace the default RPC transport, following [`@solana/kit`'s transport-augmentation pattern](https://github.com/anza-xyz/kit#augmenting-transports). The hook receives the SDK's fully configured transport (Helius URL with your API key, SDK headers, and request-id stamping) and returns the transport the client will use for **all** JSON-RPC calls — standard Solana RPC and DAS/Helius methods alike.
+`createHelius` accepts a `transport` hook that lets you augment or replace the default RPC transport, following [`@solana/kit`'s custom-transport pattern](https://github.com/anza-xyz/kit#custom-rpc-transports). The hook receives the SDK's fully configured transport (Helius URL with your API key, SDK headers, and request-id stamping) and returns the transport the client will use for **all** JSON-RPC calls — standard Solana RPC and DAS/Helius methods alike.
 
 ```ts
 import { createHelius, type RpcTransport } from "helius-sdk";
 
 const helius = createHelius({
   apiKey,
-  transport: (defaultTransport): RpcTransport => async (request) => {
+  transport: (defaultTransport: RpcTransport): RpcTransport => async (request) => {
     // Retry up to 3 times with exponential backoff
     let lastError: unknown;
     for (let attempt = 0; attempt < 3; attempt++) {
@@ -117,6 +117,8 @@ const helius = createHelius({
   },
 });
 ```
+
+For per-method policies, read the method name off the request: `(request.payload as { method: string }).method`.
 
 To replace the transport entirely (e.g., failover to a non-Helius endpoint), ignore the provided default: `transport: () => myCustomTransport`. See [`examples/helius/customTransport.ts`](examples/helius/customTransport.ts) for a full example.
 

--- a/examples/helius/customTransport.ts
+++ b/examples/helius/customTransport.ts
@@ -1,0 +1,42 @@
+import { createHelius, type RpcTransport } from "helius-sdk";
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+// Wrap the SDK's default transport with a retry policy. The wrapped
+// transport is used for every JSON-RPC call — standard Solana RPC and
+// DAS/Helius methods alike.
+const withRetries =
+  (maxAttempts: number) =>
+  (defaultTransport: RpcTransport): RpcTransport =>
+  async (request) => {
+    let lastError: unknown;
+
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      try {
+        return await defaultTransport(request);
+      } catch (error) {
+        lastError = error;
+        await sleep(2 ** attempt * 100); // Exponential backoff
+      }
+    }
+
+    throw lastError instanceof Error
+      ? lastError
+      : new Error(`RPC failed after ${maxAttempts} attempts`);
+  };
+
+(async () => {
+  const apiKey = ""; // From Helius dashboard
+  const helius = createHelius({ apiKey, transport: withRetries(3) });
+
+  try {
+    const asset = await helius.getAsset({
+      id: "F9Lw3ki3hJ7PF9HQXsBzoY8GyE6sPoEZZdXJBsTTD2rk",
+    });
+
+    console.log("Asset: ", asset);
+  } catch (error) {
+    console.error("Error with RPC: ", error);
+  }
+})();

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -6,6 +6,11 @@ const config: Config = {
     roots: ["<rootDir>/src"],
     testMatch: ["**/__tests__/**/*.ts", "**/*.test.ts"],
     moduleFileExtensions: ["ts", "js", "json"],
+    // Resolve ESM-style ".js" specifiers (e.g. lazy `import("./x.js")`) to
+    // their TypeScript sources so lazy-loaded modules work under Jest
+    moduleNameMapper: {
+        "^(\\.{1,2}/.*)\\.js$": "$1"
+    },
     transform: {
         "^.+\\.ts$": ["ts-jest", { tsconfig: "<rootDir>/tsconfig.json" }]
     },

--- a/src/rpc/createHelius.eager.ts
+++ b/src/rpc/createHelius.eager.ts
@@ -8,6 +8,7 @@ import {
 } from "@solana/kit";
 import { wrapAutoSend } from "./wrapAutoSend";
 import { makeRpcCaller } from "./caller";
+import { withSdkRequestId } from "./transport";
 import { getSDKHeaders, type AllowedRpcHeaders } from "../http";
 
 import { GetAssetFn, makeGetAsset } from "./methods/getAsset";
@@ -134,6 +135,7 @@ export const createHeliusEager = ({
   rebateAddress,
   baseUrl,
   userAgent,
+  transport: transportHook,
 }: HeliusRpcOptions): HeliusClientEager => {
   // Use custom baseUrl if provided, otherwise construct from network
   const resolvedBaseUrl = baseUrl ?? `https://${network}.helius-rpc.com/`;
@@ -151,10 +153,15 @@ export const createHeliusEager = ({
   const url = `${resolvedBaseUrl}${queryString}`;
 
   const solanaApi = createSolanaRpcApi(DEFAULT_RPC_CONFIG);
-  const transport = createDefaultRpcTransport({
-    url,
-    headers: getSDKHeaders(userAgent) as AllowedRpcHeaders,
-  });
+  const defaultTransport = withSdkRequestId(
+    createDefaultRpcTransport({
+      url,
+      headers: getSDKHeaders(userAgent) as AllowedRpcHeaders,
+    })
+  );
+  const transport = transportHook
+    ? transportHook(defaultTransport)
+    : defaultTransport;
 
   let baseRpc = createRpc({ api: solanaApi, transport });
   // Cast to any because I cba to go down this type rabbit hole

--- a/src/rpc/createHelius.eager.ts
+++ b/src/rpc/createHelius.eager.ts
@@ -8,7 +8,10 @@ import {
 } from "@solana/kit";
 import { wrapAutoSend } from "./wrapAutoSend";
 import { makeRpcCaller } from "./caller";
-import { withSdkRequestId } from "./transport";
+import { resolveTransport, withSdkRequestId } from "./transport";
+
+export type { TransportHook } from "./transport";
+export type { RpcTransport } from "@solana/kit";
 import { getSDKHeaders, type AllowedRpcHeaders } from "../http";
 
 import { GetAssetFn, makeGetAsset } from "./methods/getAsset";
@@ -153,15 +156,15 @@ export const createHeliusEager = ({
   const url = `${resolvedBaseUrl}${queryString}`;
 
   const solanaApi = createSolanaRpcApi(DEFAULT_RPC_CONFIG);
-  const defaultTransport = withSdkRequestId(
-    createDefaultRpcTransport({
-      url,
-      headers: getSDKHeaders(userAgent) as AllowedRpcHeaders,
-    })
+  const transport = resolveTransport(
+    withSdkRequestId(
+      createDefaultRpcTransport({
+        url,
+        headers: getSDKHeaders(userAgent) as AllowedRpcHeaders,
+      })
+    ),
+    transportHook
   );
-  const transport = transportHook
-    ? transportHook(defaultTransport)
-    : defaultTransport;
 
   let baseRpc = createRpc({ api: solanaApi, transport });
   // Cast to any because I cba to go down this type rabbit hole

--- a/src/rpc/index.ts
+++ b/src/rpc/index.ts
@@ -45,8 +45,10 @@ import type { WalletClient } from "../wallet/client";
 import type { AdminClient } from "../admin/client";
 import type { AuthClient } from "../auth/types";
 import type { HeliusRpcOptions } from "./types";
+import { withSdkRequestId, type TransportHook } from "./transport";
 
-export type { HeliusRpcOptions };
+export type { HeliusRpcOptions, TransportHook };
+export type { RpcTransport } from "@solana/kit";
 
 /**
  * The main Helius SDK client. Provides access to all Helius and Solana RPC
@@ -180,6 +182,7 @@ export const createHelius = ({
   rebateAddress,
   baseUrl,
   userAgent,
+  transport: transportHook,
 }: HeliusRpcOptions): HeliusClient => {
   // Use custom baseUrl if provided, otherwise construct from network
   const resolvedBaseUrl = baseUrl ?? `https://${network}.helius-rpc.com/`;
@@ -197,25 +200,15 @@ export const createHelius = ({
   const url = `${resolvedBaseUrl}${queryString}`;
 
   const solanaApi = createSolanaRpcApi(DEFAULT_RPC_CONFIG);
-  const baseTransport = createDefaultRpcTransport({
-    url,
-    headers: getSDKHeaders(userAgent) as AllowedRpcHeaders,
-  });
-  const transport = async <TResponse>(
-    request: Parameters<typeof baseTransport>[0]
-  ): Promise<TResponse> => {
-    const payload = {
-      ...(request.payload as Record<string, unknown>),
-      id: "helius-sdk",
-    };
-
-    const modifiedRequest = {
-      ...request,
-      payload,
-    };
-
-    return baseTransport(modifiedRequest) as Promise<TResponse>;
-  };
+  const defaultTransport = withSdkRequestId(
+    createDefaultRpcTransport({
+      url,
+      headers: getSDKHeaders(userAgent) as AllowedRpcHeaders,
+    })
+  );
+  const transport = transportHook
+    ? transportHook(defaultTransport)
+    : defaultTransport;
 
   const baseRpc = createRpc({ api: solanaApi, transport });
   const raw: ResolvedHeliusRpcApi = wrapAutoSend(baseRpc);

--- a/src/rpc/index.ts
+++ b/src/rpc/index.ts
@@ -45,7 +45,11 @@ import type { WalletClient } from "../wallet/client";
 import type { AdminClient } from "../admin/client";
 import type { AuthClient } from "../auth/types";
 import type { HeliusRpcOptions } from "./types";
-import { withSdkRequestId, type TransportHook } from "./transport";
+import {
+  resolveTransport,
+  withSdkRequestId,
+  type TransportHook,
+} from "./transport";
 
 export type { HeliusRpcOptions, TransportHook };
 export type { RpcTransport } from "@solana/kit";
@@ -200,15 +204,15 @@ export const createHelius = ({
   const url = `${resolvedBaseUrl}${queryString}`;
 
   const solanaApi = createSolanaRpcApi(DEFAULT_RPC_CONFIG);
-  const defaultTransport = withSdkRequestId(
-    createDefaultRpcTransport({
-      url,
-      headers: getSDKHeaders(userAgent) as AllowedRpcHeaders,
-    })
+  const transport = resolveTransport(
+    withSdkRequestId(
+      createDefaultRpcTransport({
+        url,
+        headers: getSDKHeaders(userAgent) as AllowedRpcHeaders,
+      })
+    ),
+    transportHook
   );
-  const transport = transportHook
-    ? transportHook(defaultTransport)
-    : defaultTransport;
 
   const baseRpc = createRpc({ api: solanaApi, transport });
   const raw: ResolvedHeliusRpcApi = wrapAutoSend(baseRpc);

--- a/src/rpc/tests/createHelius.test.ts
+++ b/src/rpc/tests/createHelius.test.ts
@@ -151,6 +151,89 @@ describe("createHelius", () => {
       expect(url).toContain(`api-key=${apiKey}`);
     });
   });
+
+  describe("transport hook", () => {
+    it("invokes the hook once with the default transport and uses its result", async () => {
+      const hook = jest.fn((defaultTransport: any) => defaultTransport);
+      const rpc = createHelius({ apiKey: "test-api-key", transport: hook });
+
+      expect(hook).toHaveBeenCalledTimes(1);
+      expect(typeof hook.mock.calls[0][0]).toBe("function");
+
+      const asset = await rpc.getAsset({ id: "test-id" });
+      expect(asset).toEqual({ id: "test-asset" });
+      expect(transportMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("routes DAS calls through the wrapping transport", async () => {
+      const wrapperCalls: string[] = [];
+      const rpc = createHelius({
+        apiKey: "test-api-key",
+        transport: (defaultTransport) => async (request) => {
+          wrapperCalls.push((request.payload as any).method);
+          return defaultTransport(request);
+        },
+      });
+
+      await rpc.getAsset({ id: "test-id" });
+      expect(wrapperCalls).toEqual(["getAsset"]);
+    });
+
+    it("supports retry policies around the default transport", async () => {
+      transportMock
+        .mockRejectedValueOnce(new Error("boom"))
+        .mockResolvedValueOnce({
+          jsonrpc: "2.0",
+          id: "1",
+          result: { id: "retried-asset" },
+        });
+
+      const rpc = createHelius({
+        apiKey: "test-api-key",
+        transport: (defaultTransport) => async (request) => {
+          try {
+            return await defaultTransport(request);
+          } catch {
+            return defaultTransport(request);
+          }
+        },
+      });
+
+      const asset = await rpc.getAsset({ id: "test-id" });
+      expect(asset).toEqual({ id: "retried-asset" });
+      expect(transportMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("supports full transport replacement", async () => {
+      const customTransport = jest.fn().mockResolvedValue({
+        jsonrpc: "2.0",
+        id: "1",
+        result: { id: "custom-asset" },
+      });
+      const rpc = createHelius({
+        apiKey: "test-api-key",
+        transport: () => customTransport,
+      });
+
+      const asset = await rpc.getAsset({ id: "test-id" });
+      expect(asset).toEqual({ id: "custom-asset" });
+      expect(customTransport).toHaveBeenCalledTimes(1);
+      expect(transportMock).not.toHaveBeenCalled();
+    });
+
+    it("stamps the SDK request id before the wrapped transport", async () => {
+      const rpc = createHelius({
+        apiKey: "test-api-key",
+        transport: (defaultTransport) => defaultTransport,
+      });
+
+      await rpc.getAsset({ id: "test-id" });
+
+      const request = transportMock.mock.calls[0][0] as any;
+      expect(request.payload.id).toBe("helius-sdk");
+      expect(request.payload.method).toBe("getAsset");
+    });
+  });
 });
 
 describe("createHeliusEager", () => {
@@ -295,6 +378,61 @@ describe("createHeliusEager", () => {
       // Should not throw
       expect(() => rpc.enhanced).not.toThrow();
       expect(rpc.enhanced).toBeDefined();
+    });
+  });
+
+  describe("transport hook", () => {
+    it("invokes the hook once and routes DAS calls through its transport", async () => {
+      const wrapperCalls: string[] = [];
+      const hook = jest.fn((defaultTransport: any) => async (request: any) => {
+        wrapperCalls.push(request.payload.method);
+        return defaultTransport(request);
+      });
+      const rpc = createHeliusEager({
+        apiKey: "test-api-key",
+        transport: hook,
+      });
+
+      expect(hook).toHaveBeenCalledTimes(1);
+
+      const asset = await rpc.getAsset({ id: "test-id" });
+      expect(asset).toEqual({ id: "test-asset" });
+      expect(wrapperCalls).toEqual(["getAsset"]);
+    });
+
+    it("supports retry policies around the default transport", async () => {
+      transportMock
+        .mockRejectedValueOnce(new Error("boom"))
+        .mockResolvedValueOnce({
+          jsonrpc: "2.0",
+          id: "1",
+          result: { id: "retried-asset" },
+        });
+
+      const rpc = createHeliusEager({
+        apiKey: "test-api-key",
+        transport: (defaultTransport) => async (request) => {
+          try {
+            return await defaultTransport(request);
+          } catch {
+            return defaultTransport(request);
+          }
+        },
+      });
+
+      const asset = await rpc.getAsset({ id: "test-id" });
+      expect(asset).toEqual({ id: "retried-asset" });
+      expect(transportMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("stamps the SDK request id on outgoing payloads", async () => {
+      const rpc = createHeliusEager({ apiKey: "test-api-key" });
+
+      await rpc.getAsset({ id: "test-id" });
+
+      const request = transportMock.mock.calls[0][0] as any;
+      expect(request.payload.id).toBe("helius-sdk");
+      expect(request.payload.method).toBe("getAsset");
     });
   });
 });

--- a/src/rpc/tests/createHelius.test.ts
+++ b/src/rpc/tests/createHelius.test.ts
@@ -233,6 +233,17 @@ describe("createHelius", () => {
       expect(request.payload.id).toBe("helius-sdk");
       expect(request.payload.method).toBe("getAsset");
     });
+
+    it("throws at construction when the hook does not return a transport", () => {
+      expect(() =>
+        createHelius({
+          apiKey: "test-api-key",
+          transport: (() => undefined) as any,
+        })
+      ).toThrow(
+        "The transport option must be a function that receives the default transport and returns an RpcTransport."
+      );
+    });
   });
 });
 

--- a/src/rpc/transport.ts
+++ b/src/rpc/transport.ts
@@ -1,0 +1,39 @@
+import type { RpcTransport } from "@solana/kit";
+
+/**
+ * Hook for augmenting or replacing the SDK's default RPC transport.
+ *
+ * Receives the fully configured default transport (Helius URL with API key,
+ * SDK headers, and request-id stamping) and returns the transport the client
+ * will use. Follows `@solana/kit`'s transport-augmentation pattern, enabling
+ * retries, failover, logging, and similar policies.
+ *
+ * @example
+ * ```ts
+ * const helius = createHelius({
+ *   apiKey,
+ *   transport: (defaultTransport) => async (request) => {
+ *     // custom retry / failover / logging logic around defaultTransport
+ *     return defaultTransport(request);
+ *   },
+ * });
+ * ```
+ */
+export type TransportHook = (defaultTransport: RpcTransport) => RpcTransport;
+
+/**
+ * Wrap a transport so every outgoing JSON-RPC payload is stamped with the
+ * SDK's request id.
+ */
+export const withSdkRequestId =
+  (baseTransport: RpcTransport): RpcTransport =>
+  async <TResponse>(
+    request: Parameters<RpcTransport>[0]
+  ): Promise<TResponse> => {
+    const payload = {
+      ...(request.payload as Record<string, unknown>),
+      id: "helius-sdk",
+    };
+
+    return baseTransport({ ...request, payload });
+  };

--- a/src/rpc/transport.ts
+++ b/src/rpc/transport.ts
@@ -22,6 +22,26 @@ import type { RpcTransport } from "@solana/kit";
 export type TransportHook = (defaultTransport: RpcTransport) => RpcTransport;
 
 /**
+ * Apply an optional {@link TransportHook} to the default transport, guarding
+ * against hooks that don't return a transport (e.g. a transport passed
+ * directly instead of a wrapper function).
+ */
+export const resolveTransport = (
+  defaultTransport: RpcTransport,
+  hook?: TransportHook
+): RpcTransport => {
+  if (!hook) return defaultTransport;
+
+  const transport = hook(defaultTransport);
+  if (typeof transport !== "function") {
+    throw new Error(
+      "The transport option must be a function that receives the default transport and returns an RpcTransport."
+    );
+  }
+  return transport;
+};
+
+/**
  * Wrap a transport so every outgoing JSON-RPC payload is stamped with the
  * SDK's request id.
  */

--- a/src/rpc/types.ts
+++ b/src/rpc/types.ts
@@ -1,3 +1,5 @@
+import type { TransportHook } from "./transport";
+
 /** Options for creating a Helius RPC client. */
 export interface HeliusRpcOptions {
   /** Helius API key. Required for webhooks, enhanced transactions, the Wallet API, and the Admin API. */
@@ -10,4 +12,13 @@ export interface HeliusRpcOptions {
   baseUrl?: string;
   /** Custom User-Agent string appended to outgoing HTTP requests. */
   userAgent?: string;
+  /**
+   * Augment or replace the default RPC transport. Receives the SDK's fully
+   * configured transport (Helius URL with API key, SDK headers, request-id
+   * stamping) and returns the transport used for all JSON-RPC calls —
+   * standard Solana RPC and DAS/Helius methods alike. Enables retries,
+   * failover, logging, etc. Does not affect WebSocket subscriptions or
+   * REST sub-clients (webhooks, enhanced, wallet, admin, auth).
+   */
+  transport?: TransportHook;
 }


### PR DESCRIPTION
This PR closes #345. It adds a `transport` option to `createHelius` (and `createHeliusEager`) that lets consumers augment or replace the SDK's default RPC transport, following [`@solana/kit`'s custom-transport pattern](https://github.com/anza-xyz/kit#custom-rpc-transports). The hook receives the fully configured default transport (Helius URL with API key, SDK User-Agent headers, request-id stamping) and returns the transport the client will use, enabling transport-level retries, failover, logging, and similar policies without giving up the SDK

```ts
import { createHelius, type RpcTransport } from "helius-sdk";

const helius = createHelius({
  apiKey,
  transport: (defaultTransport: RpcTransport): RpcTransport => async (request) => {
    // e.g. retry with exponential backoff; read (request.payload as { method: string }).method
    // to apply different policies per RPC method
    return defaultTransport(request);
  },
});
```

Because the wrapped transport feeds both the `@solana/kit` RPC client and the internal caller for DAS/Helius methods, one hook covers all JSON-RPC traffic (`helius.getBalance(...)` and `helius.getAsset(...)` alike). Full replacement (e.g., failover to non-Helius endpoints) works by ignoring the provided default: `transport: () => myCustomTransport`

## Changes

- `src/rpc/transport.ts` (new): `TransportHook` type, `withSdkRequestId` (id-stamping logic extracted from `createHelius`), and `resolveTransport`, which applies the hook and guards against hooks that don't return a transport (e.g., a transport passed directly instead of a wrapper), throwing a clear error at construction instead of failing cryptically at the first RPC call
- `HeliusRpcOptions.transport`: the new hook, applied in both the lazy and eager clients after id stamping, so retries re-enter the full default stack
- Main entry re-exports `TransportHook` and kit's `RpcTransport` type; `helius-sdk/rpc/eager` re-exports them too for parity
- **Consistency fix:** the eager client now stamps `id: "helius-sdk"` on outgoing payloads, matching the lazy client
- `jest.config.ts`: added the standard ts-jest `moduleNameMapper` for ESM-style `.js` specifiers; the lazy client's dynamic imports were previously untestable under Jest
- Tests: 9 new cases covering hook wiring, DAS routing through the wrapper, retry policies, full replacement, id stamping for both clients, and the misuse guard
- Docs: README section under Usage + `examples/helius/customTransport.ts`. Both snippets verified to compile in strict mode against the built package under both `moduleResolution: bundler` and `NodeNext`

## Scope notes

The hook covers JSON-RPC only. WebSocket subscriptions (`helius.ws`) and REST sub-clients (`webhooks`, `enhanced`, `wallet`, `admin`, `auth`) don't go through this transport—documented in the option's JSDoc and README. A kit-style channel-creator hook for WebSockets could be a follow-up if requested

## Testing

`pnpm format && pnpm lint && pnpm typecheck && pnpm test && pnpm check-bundle` all pass—497 tests, tree-shake check clean, `rpc/index.js` at 2.51KB (limit 2.6KB), new transport module 471B