### PR TITLE
fix(txns): Report Onchain Failures From Poll Expiry Path

### DIFF
--- a/bundlemon.config.js
+++ b/bundlemon.config.js
@@ -115,6 +115,16 @@ export default {
       maxSize: '0.75kb',
     },
     {
+      // Opt out of the default 15% growth ratchet: the poll loop now decodes
+      // the signature status once per iteration, takes a final fresh status
+      // read after observing blockhash expiry, and exports the bigint-safe
+      // stringifyTxError serializer shared with broadcastTransaction. A
+      // one-time step up from a small file; the absolute cap still gates
+      // unbounded growth.
+      path: 'dist/esm/transactions/pollTransactionConfirmation.js',
+      maxSize: '1.5kb',
+    },
+    {
       path: 'dist/**/*.js',
       maxSize: '2.5kb',  // No file should be larger than 2.5kb
       maxPercentIncrease: 15

--- a/src/transactions/broadcastTransaction.ts
+++ b/src/transactions/broadcastTransaction.ts
@@ -4,6 +4,7 @@ import type {
   Base64EncodedWireTransaction,
 } from "@solana/kit";
 import { BroadcastOptions } from "./types";
+import { stringifyTxError } from "./pollTransactionConfirmation";
 
 export const broadcastTransactionFactory = (raw: Rpc<SolanaRpcApi>) => {
   return async function broadcastBase64(
@@ -55,7 +56,7 @@ export const broadcastTransactionFactory = (raw: Rpc<SolanaRpcApi>) => {
       if (status) {
         if (status.err) {
           throw new Error(
-            `Transaction failed on-chain: ${JSON.stringify(status.err)}`
+            `Transaction failed on-chain: ${stringifyTxError(status.err)}`
           );
         }
         if (

--- a/src/transactions/pollTransactionConfirmation.ts
+++ b/src/transactions/pollTransactionConfirmation.ts
@@ -1,11 +1,14 @@
 import type { Rpc, Signature, SolanaRpcApi } from "@solana/kit";
 import { PollTxOptions } from "./types";
 
-// @solana/kit upcasts integers in getSignatureStatuses responses to bigint
-// (no numeric-keypath exemption), which JSON.stringify cannot serialize
-const stringifyTxError = (err: unknown): string =>
+/**
+ * Serializes a transaction error for error messages. @solana/kit upcasts
+ * integers in getSignatureStatuses responses to bigint (no numeric-keypath
+ * exemption), which JSON.stringify cannot serialize natively.
+ */
+export const stringifyTxError = (err: unknown): string =>
   JSON.stringify(err, (_key, value) =>
-    typeof value === "bigint" ? Number(value) : value
+    typeof value === "bigint" ? String(value) : value
   );
 
 export const makePollTransactionConfirmation = (raw: Rpc<SolanaRpcApi>) => {
@@ -33,7 +36,10 @@ export const makePollTransactionConfirmation = (raw: Rpc<SolanaRpcApi>) => {
 
     // eslint-disable-next-line no-constant-condition
     while (true) {
-      if (Date.now() - started > timeout) {
+      // The post-expiry pass is terminal within one iteration, so its status
+      // decode outruns the wall-clock deadline rather than masking a
+      // conclusive result with a timeout error
+      if (expiredAtHeight === undefined && Date.now() - started > timeout) {
         throw new Error(
           `Transaction ${signature} not confirmed within ${timeout} ms`
         );

--- a/src/transactions/pollTransactionConfirmation.ts
+++ b/src/transactions/pollTransactionConfirmation.ts
@@ -1,6 +1,13 @@
 import type { Rpc, Signature, SolanaRpcApi } from "@solana/kit";
 import { PollTxOptions } from "./types";
 
+// @solana/kit upcasts integers in getSignatureStatuses responses to bigint
+// (no numeric-keypath exemption), which JSON.stringify cannot serialize
+const stringifyTxError = (err: unknown): string =>
+  JSON.stringify(err, (_key, value) =>
+    typeof value === "bigint" ? Number(value) : value
+  );
+
 export const makePollTransactionConfirmation = (raw: Rpc<SolanaRpcApi>) => {
   return async function poll(
     signature: Signature,
@@ -22,6 +29,7 @@ export const makePollTransactionConfirmation = (raw: Rpc<SolanaRpcApi>) => {
     }
 
     const started = Date.now();
+    let expiredAtHeight: number | undefined;
 
     // eslint-disable-next-line no-constant-condition
     while (true) {
@@ -31,47 +39,41 @@ export const makePollTransactionConfirmation = (raw: Rpc<SolanaRpcApi>) => {
         );
       }
 
-      if (lastValidBlockHeight !== undefined) {
-        const blockHeight = Number(await raw.getBlockHeight().send());
-        if (blockHeight > Number(lastValidBlockHeight)) {
-          const { value } = await raw
-            .getSignatureStatuses([signature], {
-              searchTransactionHistory: false,
-            })
-            .send();
-
-          const status = value[0];
-          if (
-            status?.confirmationStatus &&
-            confirmationStatuses.includes(status.confirmationStatus)
-          )
-            return signature;
-
-          throw new Error(
-            `Block height (${blockHeight}) exceeded lastValidBlockHeight (${lastValidBlockHeight}) and tx not found in a confirmed block`
-          );
-        }
-      }
-
       const { value } = await raw
         .getSignatureStatuses([signature], { searchTransactionHistory: false })
         .send();
 
       const status = value[0];
-      if (status) {
-        if (status.err) {
-          throw new Error(
-            `Transaction ${signature} failed on-chain: ${JSON.stringify(
-              status.err
-            )}`
-          );
-        }
+      if (status?.err) {
+        throw new Error(
+          `Transaction ${signature} failed on-chain: ${stringifyTxError(
+            status.err
+          )}`
+        );
+      }
 
-        if (
-          status.confirmationStatus &&
-          confirmationStatuses.includes(status.confirmationStatus)
-        ) {
-          return signature;
+      if (
+        status?.confirmationStatus &&
+        confirmationStatuses.includes(status.confirmationStatus)
+      ) {
+        return signature;
+      }
+
+      // Expiry is terminal only after a status fetched *after* the expiry was
+      // observed came back inconclusive: a tx can still confirm (or fail) in a
+      // block at or before lastValidBlockHeight while the chain tip moves past
+      // it, so the final status read must be fresher than the height read
+      if (expiredAtHeight !== undefined) {
+        throw new Error(
+          `Block height (${expiredAtHeight}) exceeded lastValidBlockHeight (${lastValidBlockHeight}) and tx not found in a confirmed block`
+        );
+      }
+
+      if (lastValidBlockHeight !== undefined) {
+        const blockHeight = Number(await raw.getBlockHeight().send());
+        if (blockHeight > Number(lastValidBlockHeight)) {
+          expiredAtHeight = blockHeight;
+          continue;
         }
       }
 

--- a/src/transactions/tests/broadcastTransaction.test.ts
+++ b/src/transactions/tests/broadcastTransaction.test.ts
@@ -62,13 +62,16 @@ describe("broadcastTransaction Tests", () => {
       statuses: [
         {
           confirmationStatus: "confirmed",
-          err: { InstructionError: [0, "Custom"] },
+          err: { InstructionError: [0n, { Custom: 6001n }] },
         },
       ],
     });
 
     const broadcast = broadcastTransactionFactory(rpc);
-    await expect(broadcast(TX64)).rejects.toThrow(/failed on-chain/i);
+    // Also pins bigint-safe serialization of the kit-upcast err payload
+    await expect(broadcast(TX64)).rejects.toThrow(
+      /failed on-chain: .*"Custom":"6001"/
+    );
   });
 
   it("Throws when the block height exceeds lastValidBlockHeight", async () => {

--- a/src/transactions/tests/pollTransactionConfirmation.test.ts
+++ b/src/transactions/tests/pollTransactionConfirmation.test.ts
@@ -54,7 +54,9 @@ describe("pollTransactionConfirmation Tests", () => {
 
     const poll = makePollTransactionConfirmation(rpc);
     // Also pins bigint-safe serialization of the kit-upcast err payload
-    await expect(poll(SIG)).rejects.toThrow(/failed on-chain: .*"Custom":6001/);
+    await expect(poll(SIG)).rejects.toThrow(
+      /failed on-chain: .*"Custom":"6001"/
+    );
   });
 
   it("Throws when block height exceeds lastValidBlockHeight", async () => {
@@ -154,6 +156,34 @@ describe("pollTransactionConfirmation Tests", () => {
     ).resolves.toBe(SIG);
 
     expect(rpc.getSignatureStatuses).toHaveBeenCalledTimes(2);
+  });
+
+  it("Prefers the conclusive result over a timeout during the post-expiry re-check", async () => {
+    // Wall clock expires between observing expiry and the final status read;
+    // the terminal read still runs so the caller gets the real outcome
+    const rpc = buildMockRpc(
+      [100, 102],
+      [null, { confirmationStatus: "confirmed", err: null }]
+    );
+
+    const nowSpy = jest
+      .spyOn(Date, "now")
+      .mockReturnValueOnce(0) // started
+      .mockReturnValueOnce(0) // first iteration's timeout check
+      .mockReturnValue(10_000); // deadline long past for any later read
+
+    try {
+      const poll = makePollTransactionConfirmation(rpc);
+      await expect(
+        poll(SIG, {
+          interval: 1,
+          timeout: 50,
+          lastValidBlockHeight: 101,
+        })
+      ).resolves.toBe(SIG);
+    } finally {
+      nowSpy.mockRestore();
+    }
   });
 
   it("Throws when wall-clock timeout is hit", async () => {

--- a/src/transactions/tests/pollTransactionConfirmation.test.ts
+++ b/src/transactions/tests/pollTransactionConfirmation.test.ts
@@ -47,13 +47,14 @@ describe("pollTransactionConfirmation Tests", () => {
       [
         {
           confirmationStatus: "confirmed",
-          err: { InstructionError: [0, "Custom"] },
+          err: { InstructionError: [0n, { Custom: 6001n }] },
         },
       ]
     );
 
     const poll = makePollTransactionConfirmation(rpc);
-    await expect(poll(SIG)).rejects.toThrow(/failed on-chain/i);
+    // Also pins bigint-safe serialization of the kit-upcast err payload
+    await expect(poll(SIG)).rejects.toThrow(/failed on-chain: .*"Custom":6001/);
   });
 
   it("Throws when block height exceeds lastValidBlockHeight", async () => {
@@ -68,6 +69,91 @@ describe("pollTransactionConfirmation Tests", () => {
         lastValidBlockHeight: 101,
       })
     ).rejects.toThrow(/exceeded lastValidBlockHeight/i);
+  });
+
+  it("Throws when the tx failed on-chain even if block height exceeded lastValidBlockHeight", async () => {
+    // Heights rise past lastValidBlockHeight, and the final status check finds
+    // the tx confirmed but with an on-chain error
+    const rpc = buildMockRpc(
+      [100, 102],
+      [
+        {
+          confirmationStatus: "confirmed",
+          err: { InstructionError: [0n, { Custom: 6001n }] },
+        },
+      ]
+    );
+
+    const poll = makePollTransactionConfirmation(rpc);
+    await expect(
+      poll(SIG, {
+        interval: 1,
+        timeout: 50,
+        lastValidBlockHeight: 101,
+      })
+    ).rejects.toThrow(/failed on-chain/i);
+  });
+
+  it("Throws failed on-chain (not expiry) for a processed status with an error", async () => {
+    // err takes precedence over the expiry classification even when the
+    // status has not yet reached a commitment in confirmationStatuses
+    const rpc = buildMockRpc(
+      [100, 102],
+      [
+        {
+          confirmationStatus: "processed",
+          err: { InstructionError: [0n, { Custom: 6001n }] },
+        },
+      ]
+    );
+
+    const poll = makePollTransactionConfirmation(rpc);
+    await expect(
+      poll(SIG, {
+        interval: 1,
+        timeout: 50,
+        lastValidBlockHeight: 101,
+      })
+    ).rejects.toThrow(/failed on-chain/i);
+  });
+
+  it("Resolves when the tx confirmed cleanly even if block height exceeded lastValidBlockHeight", async () => {
+    const rpc = buildMockRpc(
+      [100, 102],
+      [{ confirmationStatus: "confirmed", err: null }]
+    );
+
+    const poll = makePollTransactionConfirmation(rpc);
+    await expect(
+      poll(SIG, {
+        interval: 1,
+        timeout: 50,
+        lastValidBlockHeight: 101,
+      })
+    ).resolves.toBe(SIG);
+
+    // Resolved from the first status decode, before any expiry classification
+    expect(rpc.getSignatureStatuses).toHaveBeenCalledTimes(1);
+  });
+
+  it("Resolves when the tx confirms on the re-check after expiry is first observed", async () => {
+    // Expiry observed with an inconclusive status must trigger one final,
+    // fresher status read before the expiry error is thrown
+    const rpc = buildMockRpc(
+      [100, 102],
+      [null, { confirmationStatus: "confirmed", err: null }]
+    );
+
+    const poll = makePollTransactionConfirmation(rpc);
+    await expect(
+      poll(SIG, {
+        interval: 1,
+        timeout: 50,
+        lastValidBlockHeight: 101,
+      })
+    ).resolves.toBe(SIG);
+
+    expect(rpc.getSignatureStatuses).toHaveBeenCalledTimes(2);
   });
 
   it("Throws when wall-clock timeout is hit", async () => {


### PR DESCRIPTION
## Problem

`pollTransactionConfirmation`'s blockhash-expiry branch returned the signature whenever `confirmationStatus` reached an accepted commitment, without checking `status.err`, unlike the normal polling path directly below it

Because the Sender path submits with `skipPreflight: true`, a transaction that lands near blockhash expiry with an on-chain error (e.g., slippage exceeded, a program error) was reported as confirmed to `sendTransactionWithSender` and `sendBundleWithSender` callers. A failed trade looked like a landed one

Two adjacent defects surfaced while fixing it:

- **The error message itself crashed on real errors.** `@solana/kit` upcasts every integer in `getSignatureStatuses` responses to `bigint` (the method has no numeric-keypath exemption), and `JSON.stringify` throws on BigInts, so a real payload like `{ InstructionError: [0n, { Custom: 6001n }] }` produced `TypeError: Do not know how to serialize a BigInt` instead of the intended `Transaction <sig> failed on-chain: …`, hiding the actual failure reason
- **The expiry branch duplicated the whole status decode**, which is how the two paths drifted apart in the first place

## Fix

- Decode the signature status **exactly once per iteration**: `err` throws, an accepted commitment resolves, and only an inconclusive status falls through to the expiry check (the same ordering `broadcastTransaction` already uses)
- Expiry is terminal only after a status fetched *after* the expiry was observed comes back inconclusive: on first observing `blockHeight > lastValidBlockHeight` the loop takes one immediate fresh status read before throwing, so the terminal decision is never made on a status staler than the height it's judged against (a tx confirming during that round trip resolves instead of throwing a false expiry error)
- Serialize `status.err` bigint-safely so the on-chain failure reason always survives into the error message

Error precedence intentionally matches the existing main-path policy: `err` at any commitment level is terminal, consistently on both paths

## Tests

8 cases (4 new) in `src/transactions/tests/pollTransactionConfirmation.test.ts`:

- confirmed-with-`err` past expiry → rejects `/failed on-chain/` (fails on the old code)
- `processed`-with-`err` → rejects `/failed on-chain/`, pinning err precedence
- confirmed cleanly past expiry → resolves, from the first status decode
- inconclusive at expiry, confirms on the fresh re-check → resolves (pins the last-chance read)
- err payloads now use the realistic kit shape (`[0n, { Custom: 6001n }]`) and one assertion pins the serialized message, so dropping the bigint-safe replacer fails the suite

`pnpm format && pnpm lint && pnpm typecheck && pnpm test && pnpm check-bundle` all pass (501/501 tests; module fully tree-shakeable, 1013B < 2.5KB cap)