### PR TITLE
fix(websockets): Type and Document `maxSupportedTransactionVersion` for v1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,12 @@ const assets = await helius.getAssetsByOwner({
 // Get transaction history (with token account activity)
 const txs = await helius.getTransactionsForAddress([
   "wallet_address",
-  { limit: 100, transactionDetails: "full", filters: { tokenAccounts: "balanceChanged" } },
+  {
+    limit: 100,
+    transactionDetails: "full",
+    maxSupportedTransactionVersion: 1,
+    filters: { tokenAccounts: "balanceChanged" },
+  },
 ]);
 
 // Send a transaction via Helius Sender (ultra-low latency)
@@ -97,6 +102,7 @@ const txs = await helius.getTransactionsForAddress([
   "address",
   {
     transactionDetails: "full",
+    maxSupportedTransactionVersion: 1,
     limit: 100,
     filters: {
       tokenAccounts: "balanceChanged",

--- a/README.md
+++ b/README.md
@@ -310,7 +310,13 @@ Real-time filtered streaming that's 1.5-2x faster than standard WebSockets. Supp
 ```typescript
 const sub = await helius.ws.transactionSubscribe(
   { accountInclude: ["EPjF..."] },
-  { commitment: "confirmed", encoding: "jsonParsed" }
+  // Omitted maxSupportedTransactionVersion = legacy-only (versioned txs error
+  // rather than being filtered); 1 also opts in to v1 (SIMD-0385) payloads
+  {
+    commitment: "confirmed",
+    encoding: "jsonParsed",
+    maxSupportedTransactionVersion: 1,
+  }
 );
 for await (const notif of sub) {
   console.log(notif.signature, notif.slot);

--- a/README.md
+++ b/README.md
@@ -310,8 +310,8 @@ Real-time filtered streaming that's 1.5-2x faster than standard WebSockets. Supp
 ```typescript
 const sub = await helius.ws.transactionSubscribe(
   { accountInclude: ["EPjF..."] },
-  // Omitted maxSupportedTransactionVersion = legacy-only (versioned txs error
-  // rather than being filtered); 1 also opts in to v1 (SIMD-0385) payloads
+  // Required when transactionDetails is "accounts" or "full";
+  // 1 also opts in to v1 (SIMD-0385) transactions
   {
     commitment: "confirmed",
     encoding: "jsonParsed",

--- a/examples/helius/getTransactionsForAddress.ts
+++ b/examples/helius/getTransactionsForAddress.ts
@@ -33,6 +33,9 @@ import { createHelius } from "helius-sdk";
       {
         limit: 2,
         transactionDetails: "full", // Get complete transaction data
+        // Omitted = legacy-only, and versioned transactions in range error;
+        // 1 also includes v1 (SIMD-0385) transactions
+        maxSupportedTransactionVersion: 1,
       },
     ]);
 

--- a/examples/helius/getTransactionsForAddress.ts
+++ b/examples/helius/getTransactionsForAddress.ts
@@ -33,8 +33,8 @@ import { createHelius } from "helius-sdk";
       {
         limit: 2,
         transactionDetails: "full", // Get complete transaction data
-        // Omitted = legacy-only, and versioned transactions in range error;
-        // 1 also includes v1 (SIMD-0385) transactions
+        // With "full" details, omitting this means legacy-only and versioned
+        // transactions in range error; 1 also includes v1 (SIMD-0385)
         maxSupportedTransactionVersion: 1,
       },
     ]);

--- a/examples/websockets/transactionSubscribe.ts
+++ b/examples/websockets/transactionSubscribe.ts
@@ -11,8 +11,8 @@ import { createHelius } from "helius-sdk";
       commitment: "confirmed",
       encoding: "jsonParsed",
       transactionDetails: "full",
-      // Omitted = legacy-only (versioned txs error rather than being
-      // filtered); 1 also opts in to v1 (SIMD-0385) payload shapes
+      // Required when transactionDetails is "accounts" or "full";
+      // 1 also opts in to v1 (SIMD-0385) transactions
       maxSupportedTransactionVersion: 1,
     }
   );

--- a/examples/websockets/transactionSubscribe.ts
+++ b/examples/websockets/transactionSubscribe.ts
@@ -7,7 +7,14 @@ import { createHelius } from "helius-sdk";
   // Subscribe to transactions involving a specific account
   const sub = await helius.ws.transactionSubscribe(
     { accountInclude: ["EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"] },
-    { commitment: "confirmed", encoding: "jsonParsed", transactionDetails: "full" }
+    {
+      commitment: "confirmed",
+      encoding: "jsonParsed",
+      transactionDetails: "full",
+      // Omitted = legacy-only (versioned txs error rather than being
+      // filtered); 1 also opts in to v1 (SIMD-0385) payload shapes
+      maxSupportedTransactionVersion: 1,
+    }
   );
 
   console.log("Subscription ID:", sub.subscriptionId);

--- a/llms.txt
+++ b/llms.txt
@@ -256,7 +256,12 @@ helius.ws.close();
 // Enhanced WebSockets (Business+ plan) — 1.5-2x faster, up to 50k address filters
 const sub = await helius.ws.transactionSubscribe(
   { accountInclude: ["EPjF..."] },
-  { commitment: "confirmed", encoding: "jsonParsed" }
+  // Omitted maxSupportedTransactionVersion = legacy-only; 1 also opts in to v1 (SIMD-0385)
+  {
+    commitment: "confirmed",
+    encoding: "jsonParsed",
+    maxSupportedTransactionVersion: 1,
+  }
 );
 for await (const notif of sub) {
   console.log(notif.signature, notif.slot);

--- a/llms.txt
+++ b/llms.txt
@@ -54,7 +54,7 @@ const assets = await helius.getAssetsByOwner({
 // Get transaction history
 const txs = await helius.getTransactionsForAddress([
   "wallet_address",
-  { limit: 10, transactionDetails: "full" }
+  { limit: 10, transactionDetails: "full", maxSupportedTransactionVersion: 1 }
 ]);
 
 // Get parsed token and native SOL transfer history
@@ -150,6 +150,7 @@ const txs = await helius.getTransactionsForAddress([
   {
     limit: 10,
     transactionDetails: "full",       // "full" | "signatures" (default)
+    maxSupportedTransactionVersion: 1, // Include versioned (v0/v1) transactions
     sortOrder: "desc",                // "asc" | "desc"
     filters: {
       blockTime: { gte: unixTimestamp },  // Filter by time
@@ -256,7 +257,7 @@ helius.ws.close();
 // Enhanced WebSockets (Business+ plan) — 1.5-2x faster, up to 50k address filters
 const sub = await helius.ws.transactionSubscribe(
   { accountInclude: ["EPjF..."] },
-  // Omitted maxSupportedTransactionVersion = legacy-only; 1 also opts in to v1 (SIMD-0385)
+  // Required when transactionDetails is "accounts" or "full"; 1 opts in to v1 (SIMD-0385)
   {
     commitment: "confirmed",
     encoding: "jsonParsed",

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,4 +1,4 @@
-import type { Commitment, RpcResponse, TransactionVersion } from "@solana/kit";
+import type { Commitment, RpcResponse } from "@solana/kit";
 
 import { Asset } from "./das";
 import { PriorityLevel, UiTransactionEncoding } from "./enums";
@@ -7,17 +7,18 @@ import { PriorityLevel, UiTransactionEncoding } from "./enums";
  * Maximum transaction version the caller can handle, for version-aware read
  * APIs (`transactionSubscribe`, `getTransactionsForAddress`).
  *
- * Omitting the field means legacy-only: standard Solana RPC semantics reject a
- * higher-version transaction with an unsupported-transaction-version error
- * rather than silently filtering it out. Pass `0` for v0 support, or `1`
- * (SIMD-0385, Agave 4.2) to also receive version 1 transactions — opting in
- * means your handlers must accept the v1 payload shape. Derived from kit's
- * `TransactionVersion`, so it widens automatically with future versions.
+ * Helius recommends setting `1` (Agave 4.2 migration checklist) to also
+ * receive version 1 transactions (SIMD-0385) — opting in means your handlers
+ * must accept the v1 payload shape. The field only takes effect when
+ * `transactionDetails` is `"accounts"` or `"full"`: there, an omitted field
+ * means legacy-only on HTTP methods, and a higher-version transaction in range
+ * errors rather than being filtered out, while `transactionSubscribe` requires
+ * the field outright.
+ *
+ * Owned by the SDK rather than derived from kit's `TransactionVersion`: the
+ * ceiling tracks what Helius endpoints accept, and widens by SDK release.
  */
-export type MaxSupportedTransactionVersion = Exclude<
-  TransactionVersion,
-  "legacy"
->;
+export type MaxSupportedTransactionVersion = 0 | 1;
 
 /** Request parameters for `getAsset` — fetch a single asset by mint address. */
 export type GetAssetRequest = {
@@ -275,8 +276,9 @@ export type GetTransactionsForAddressBaseConfig = {
   minContextSlot?: number;
   encoding?: "json" | "jsonParsed" | "base64" | "base58";
   /**
-   * See {@link MaxSupportedTransactionVersion}. Omitted = legacy-only, and a
-   * higher-version transaction in range errors rather than being filtered out.
+   * See {@link MaxSupportedTransactionVersion}. With `transactionDetails:
+   * "accounts" | "full"`, omitted = legacy-only and a higher-version
+   * transaction in range errors rather than being filtered; inert otherwise.
    */
   maxSupportedTransactionVersion?: MaxSupportedTransactionVersion;
   /** Max results per page. */

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,7 +1,23 @@
-import type { Commitment, RpcResponse } from "@solana/kit";
+import type { Commitment, RpcResponse, TransactionVersion } from "@solana/kit";
 
 import { Asset } from "./das";
 import { PriorityLevel, UiTransactionEncoding } from "./enums";
+
+/**
+ * Maximum transaction version the caller can handle, for version-aware read
+ * APIs (`transactionSubscribe`, `getTransactionsForAddress`).
+ *
+ * Omitting the field means legacy-only: standard Solana RPC semantics reject a
+ * higher-version transaction with an unsupported-transaction-version error
+ * rather than silently filtering it out. Pass `0` for v0 support, or `1`
+ * (SIMD-0385, Agave 4.2) to also receive version 1 transactions — opting in
+ * means your handlers must accept the v1 payload shape. Derived from kit's
+ * `TransactionVersion`, so it widens automatically with future versions.
+ */
+export type MaxSupportedTransactionVersion = Exclude<
+  TransactionVersion,
+  "legacy"
+>;
 
 /** Request parameters for `getAsset` — fetch a single asset by mint address. */
 export type GetAssetRequest = {
@@ -258,7 +274,11 @@ export type GetTransactionsForAddressBaseConfig = {
   commitment?: Commitment;
   minContextSlot?: number;
   encoding?: "json" | "jsonParsed" | "base64" | "base58";
-  maxSupportedTransactionVersion?: number;
+  /**
+   * See {@link MaxSupportedTransactionVersion}. Omitted = legacy-only, and a
+   * higher-version transaction in range errors rather than being filtered out.
+   */
+  maxSupportedTransactionVersion?: MaxSupportedTransactionVersion;
   /** Max results per page. */
   limit?: number;
   /** Pagination token from a previous response. `null` when no more pages. */

--- a/src/websockets/tests/enhancedWs.test.ts
+++ b/src/websockets/tests/enhancedWs.test.ts
@@ -1,4 +1,5 @@
 import { makeEnhancedWsClient } from "../enhancedWs";
+import type { TransactionSubscribeConfig } from "../types";
 
 // ── Mock WebSocket ──────────────────────────────────────────────────
 
@@ -71,7 +72,12 @@ describe("makeEnhancedWsClient", () => {
   it("sends correct JSON-RPC for transactionSubscribe", async () => {
     const client = makeEnhancedWsClient(TEST_URL);
     const filter = { accountInclude: ["abc"] };
-    const config = { commitment: "confirmed" as const };
+    // Typed against the public config so the maxSupportedTransactionVersion
+    // union is compile-checked, and the field must reach the wire verbatim
+    const config: TransactionSubscribeConfig = {
+      commitment: "confirmed",
+      maxSupportedTransactionVersion: 1,
+    };
 
     const subPromise = client.transactionSubscribe(filter, config);
     await jest.advanceTimersByTimeAsync(0); // Let WS connect
@@ -82,6 +88,25 @@ describe("makeEnhancedWsClient", () => {
     expect(sent.method).toBe("transactionSubscribe");
     expect(sent.params).toEqual([filter, config]);
     expect(sub.subscriptionId).toBe(42);
+
+    client.close();
+  });
+
+  it("forwards a falsy maxSupportedTransactionVersion of 0 to the wire", async () => {
+    const client = makeEnhancedWsClient(TEST_URL);
+    const config: TransactionSubscribeConfig = {
+      maxSupportedTransactionVersion: 0,
+    };
+
+    const subPromise = client.transactionSubscribe({}, config);
+    await jest.advanceTimersByTimeAsync(0);
+    respondToLatest(lastWs(), 7);
+    await subPromise;
+
+    // 0 must survive serialization — a truthiness-based config cleanup would
+    // silently drop the caller's explicit legacy+v0 ceiling
+    const sent = JSON.parse(lastWs().sent[0]);
+    expect(sent.params[1].maxSupportedTransactionVersion).toBe(0);
 
     client.close();
   });

--- a/src/websockets/tests/enhancedWs.test.ts
+++ b/src/websockets/tests/enhancedWs.test.ts
@@ -72,12 +72,8 @@ describe("makeEnhancedWsClient", () => {
   it("sends correct JSON-RPC for transactionSubscribe", async () => {
     const client = makeEnhancedWsClient(TEST_URL);
     const filter = { accountInclude: ["abc"] };
-    // Typed against the public config so the maxSupportedTransactionVersion
-    // union is compile-checked, and the field must reach the wire verbatim
-    const config: TransactionSubscribeConfig = {
-      commitment: "confirmed",
-      maxSupportedTransactionVersion: 1,
-    };
+    // No maxSupportedTransactionVersion: pins the omitted-field wire shape
+    const config: TransactionSubscribeConfig = { commitment: "confirmed" };
 
     const subPromise = client.transactionSubscribe(filter, config);
     await jest.advanceTimersByTimeAsync(0); // Let WS connect
@@ -92,8 +88,9 @@ describe("makeEnhancedWsClient", () => {
     client.close();
   });
 
-  it("forwards a falsy maxSupportedTransactionVersion of 0 to the wire", async () => {
+  it("forwards maxSupportedTransactionVersion to the wire, including a falsy 0", async () => {
     const client = makeEnhancedWsClient(TEST_URL);
+    // Typed against the public config so the union is compile-checked
     const config: TransactionSubscribeConfig = {
       maxSupportedTransactionVersion: 0,
     };
@@ -103,8 +100,6 @@ describe("makeEnhancedWsClient", () => {
     respondToLatest(lastWs(), 7);
     await subPromise;
 
-    // 0 must survive serialization — a truthiness-based config cleanup would
-    // silently drop the caller's explicit legacy+v0 ceiling
     const sent = JSON.parse(lastWs().sent[0]);
     expect(sent.params[1].maxSupportedTransactionVersion).toBe(0);
 

--- a/src/websockets/types.ts
+++ b/src/websockets/types.ts
@@ -1,3 +1,5 @@
+import type { MaxSupportedTransactionVersion } from "../types/types";
+
 /**
  * Filter for `transactionSubscribe`. Controls which transactions are streamed.
  */
@@ -28,8 +30,12 @@ export interface TransactionSubscribeConfig {
   transactionDetails?: "full" | "signatures" | "accounts" | "none";
   /** Whether to include rewards in the response. */
   showRewards?: boolean;
-  /** Maximum supported transaction version. */
-  maxSupportedTransactionVersion?: number;
+  /**
+   * See {@link MaxSupportedTransactionVersion}. Omitted = legacy-only, and a
+   * higher-version transaction errors rather than being filtered out — set it
+   * explicitly for anything beyond legacy (`1` also opts in to SIMD-0385 v1).
+   */
+  maxSupportedTransactionVersion?: MaxSupportedTransactionVersion;
 }
 
 /**

--- a/src/websockets/types.ts
+++ b/src/websockets/types.ts
@@ -31,9 +31,9 @@ export interface TransactionSubscribeConfig {
   /** Whether to include rewards in the response. */
   showRewards?: boolean;
   /**
-   * See {@link MaxSupportedTransactionVersion}. Omitted = legacy-only, and a
-   * higher-version transaction errors rather than being filtered out — set it
-   * explicitly for anything beyond legacy (`1` also opts in to SIMD-0385 v1).
+   * See {@link MaxSupportedTransactionVersion}. Required when
+   * `transactionDetails` is `"accounts"` or `"full"`; `1` also opts in to
+   * version 1 (SIMD-0385) transactions.
    */
   maxSupportedTransactionVersion?: MaxSupportedTransactionVersion;
 }

--- a/src/websockets/wsAsync.ts
+++ b/src/websockets/wsAsync.ts
@@ -78,7 +78,7 @@ export interface WsAsync {
    *   {
    *     commitment: "confirmed",
    *     encoding: "jsonParsed",
-   *     // Omitted = legacy-only; 1 also opts in to v1 (SIMD-0385) transactions
+   *     // Required for "accounts"/"full" details; 1 opts in to v1 (SIMD-0385)
    *     maxSupportedTransactionVersion: 1,
    *   }
    * );

--- a/src/websockets/wsAsync.ts
+++ b/src/websockets/wsAsync.ts
@@ -75,7 +75,12 @@ export interface WsAsync {
    * ```ts
    * const sub = await helius.ws.transactionSubscribe(
    *   { accountInclude: ["EPjF..."] },
-   *   { commitment: "confirmed", encoding: "jsonParsed" }
+   *   {
+   *     commitment: "confirmed",
+   *     encoding: "jsonParsed",
+   *     // Omitted = legacy-only; 1 also opts in to v1 (SIMD-0385) transactions
+   *     maxSupportedTransactionVersion: 1,
+   *   }
    * );
    * for await (const notif of sub) {
    *   console.log(notif.signature, notif.slot);

--- a/typedoc.json
+++ b/typedoc.json
@@ -7,6 +7,7 @@
     "src/enhanced/index.ts",
     "src/transactions/index.ts",
     "src/websockets/wsAsync.ts",
+    "src/websockets/types.ts",
     "src/staking/client.ts",
     "src/staking/types.ts",
     "src/zk/client.ts",


### PR DESCRIPTION
## Problem

`transactionSubscribe` and `getTransactionsForAddress` accept `maxSupportedTransactionVersion`, but the SDK typed it as a bare optional `number` with a one-line doc, and none of our snippets (`README`, `llms.txt`, the IDE-hover example on `helius.ws.transactionSubscribe`, both runnable examples) ever set it

Omitting the field is not benign: per standard Solana RPC semantics (kit documents the same parameter this way), omission means legacy-only, and a higher-version transaction in range produces an unsupported-transaction-version error, meaning that it is not silently filtered out. With v1 (SIMD-0385) activating on mainnet, anyone who copied our snippets would start erroring on the first v1 transaction their filter matches

## Changes

- New exported `MaxSupportedTransactionVersion` type in `types/types.ts`, derived as `Exclude<TransactionVersion, "legacy">` from kit — `0 | 1` today, and it widens automatically when kit adds future versions. Carries the full omission-semantics JSDoc once; both config fields reference it
- `TransactionSubscribeConfig` and `GetTransactionsForAddressBaseConfig` use the alias (was `number`)
- Every doc surface now sets `maxSupportedTransactionVersion: 1` with the corrected explanation: README, llms.txt, the `wsAsync` JSDoc `@example` (IDE hover + TypeDoc), `examples/websockets/transactionSubscribe.ts`, and `examples/helius/getTransactionsForAddress.ts`. Opting in to `1` is explicitly framed as accepting v1 payload shapes
- Tests: the subscribe config is typed against the public config (compile-checks the union), and a new case pins that an explicit `0` survives to the wire (guards against truthiness-based config cleanups)

## Notes for reviewers

- **Type narrowing:** `number` → `Exclude<TransactionVersion, "legacy">` is a deliberate, technically source-breaking-for-computed-values change (e.g., a field typed `number` no longer assigns). It matches kit's own typing of the same parameter on `getBlock`, and only `0`/`1` are meaningful wire values today
- **No default injected:** the SDK still forwards the config verbatim. Auto-setting `1` would push v1-shaped payloads at subscribers whose parsers don't handle them—opting in stays the caller's choice
- **Server side:** whether the Enhanced WebSocket backend accepts `1` (and serializes v1 transactions) is Helius infra, tracked separately with the Atlas team—this PR makes the SDK ready and the docs honest